### PR TITLE
Allow skipping R/R display for specific channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ README.md            # This file
    python app.py
    ```
 
-4. Open http://127.0.0.1:5000 in your browser and fill in your API ID, API hash, session string, source channels and destination channels.  Click **Start Bot** to begin forwarding.
+4. Open http://127.0.0.1:5000 in your browser and fill in your API ID, API hash, session string, source channels and destination channels. Optionally provide channel IDs in **skip_rr_channels** to suppress R/R values for those chats. Click **Start Bot** to begin forwarding.
 
 ## Deploying to Render
 
@@ -67,6 +67,7 @@ README.md            # This file
    * `API_HASH` – your Telegram API hash.
    * `SOURCES` – a JSON array of source channel usernames or numeric IDs (e.g. `["@sourceA", -1001234567890]`).
    * `DESTS` – a JSON array of destination channel usernames or numeric IDs.
+   * `SKIP_RR_CHANNELS` – optional JSON array or comma-separated list of channel IDs for which risk/reward should be omitted.
    * `SESSION_STRING` – the session string generated earlier.
 
 5. Deploy the service.  Once running, visit `/` to configure the bot if you have not set environment variables.  The dashboard allows you to start and stop the bot without redeploying.

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,8 @@
     </div>
     <label>کانال‌های منبع (JSON یا لیست با کاما)</label>
     <textarea name="from_channels" placeholder='[1467736193, 2123816390, 1286609636]'>{{ (cfg.from_channels if cfg else '') or '[1467736193, 2123816390, 1286609636]' }}</textarea>
+    <label>شناسه کانال‌هایی که R/R نمایش داده نشود</label>
+    <input name="skip_rr_channels" placeholder="123456789, -100987654321" value="{{ (cfg.skip_rr_channels if cfg else '') or '' }}">
     <div class="btns">
       <button class="primary" type="submit">ذخیره</button>
     </div>


### PR DESCRIPTION
## Summary
- Add `skip_rr_channels` input to dashboard and store in config
- Parse channel IDs and pass `skip_rr_chat_ids` set to `SignalBot`
- Document `SKIP_RR_CHANNELS` environment variable

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41d6be54083239d3adfbb4816c598