### PR TITLE
Add Channel Four parser and comprehensive tests

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -154,8 +154,12 @@ def extract_tps(lines: List[str]) -> List[str]:
         if not any(k in ll for k in TP_KEYS):
             continue
 
-        # 1) اول تلاش کن الگوی استاندارد «TPn : قیمت» را بگیری
-        m = re.search(r'\bTP\s*\d*\s*[:\-]\s*(-?\d+(?:\.\d+)?)', l, re.IGNORECASE)
+        # 1) اول تلاش کن الگوی استاندارد «TPn : قیمت» یا «Take Profit n : قیمت» را بگیری
+        m = re.search(
+            r'\b(?:TP|Take\s+Profit)\s*\d*\s*[:\-]\s*(-?\d+(?:\.\d+)?)',
+            l,
+            re.IGNORECASE,
+        )
         if m:
             tps.append(m.group(1))
             continue
@@ -166,7 +170,10 @@ def extract_tps(lines: List[str]) -> List[str]:
             num = nm.group(1)
 
             # اگر خط شامل TP بود، اعداد خیلی کوچک و بدون اعشار (شماره TP) را رد کن
-            if re.search(r'\bTP\b', l, re.IGNORECASE) and re.fullmatch(r'\d+', num):
+            if (
+                re.search(r'\b(?:TP|Take\s+Profit)\b', l, re.IGNORECASE)
+                and re.fullmatch(r'\d+', num)
+            ):
                 # معمولاً شماره‌های TP کوچک‌اند؛ ردش کن
                 if int(num) <= 10:
                     continue
@@ -289,6 +296,68 @@ def parse_signal_united_kings(
 
     return to_unified(signal, chat_id, skip_rr_for)
 
+
+def parse_channel_four(
+    text: str, chat_id: int, skip_rr_for: Iterable[int] = ()
+) -> Optional[str]:
+    """Parser for Channel Four style messages supporting entry ranges."""
+    if looks_like_update(text):
+        log.info("IGNORED (update/noise)")
+        return None
+
+    lines = [l.strip() for l in (text or "").splitlines() if l and l.strip()]
+    if not lines:
+        log.info("IGNORED (empty)")
+        return None
+
+    symbol = guess_symbol(text) or ""
+    position = guess_position(text) or ""
+    entry = extract_entry(lines) or ""
+    sl = extract_sl(lines) or ""
+    tps = extract_tps(lines)
+    rr = extract_rr(text)
+
+    entry_range: Optional[Tuple[str, str]] = None
+    for l in lines:
+        ll = l.lower()
+        if any(k in ll for k in ENTRY_KEYS):
+            m = re.search(r"(-?\d+(?:\.\d+)?)[^\d]+(-?\d+(?:\.\d+)?)", l)
+            if m:
+                entry_range = (m.group(1), m.group(2))
+                if not entry:
+                    entry = m.group(1)
+                break
+
+    signal = {
+        "symbol": symbol,
+        "position": position,
+        "entry": entry,
+        "sl": sl,
+        "tps": tps,
+        "rr": rr,
+        "extra": {},
+    }
+    if entry_range:
+        signal["extra"]["entries"] = {"range": entry_range}
+
+    if not is_valid(signal):
+        log.info(f"IGNORED (invalid) -> {signal}")
+        return None
+
+    try:
+        e = float(entry)
+        if position.upper().startswith("SELL"):
+            if all(float(tp) > e for tp in tps):
+                log.info("IGNORED (sell but all TP > entry)")
+                return None
+        if position.upper().startswith("BUY"):
+            if all(float(tp) < e for tp in tps):
+                log.info("IGNORED (buy but all TP < entry)")
+                return None
+    except Exception:
+        pass
+
+    return to_unified(signal, chat_id, skip_rr_for, signal.get("extra", {}))
 
 def parse_signal(text: str, chat_id: int, skip_rr_for: Iterable[int] = ()) -> Optional[str]:
     text = normalize_numbers(text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure the repository root is on sys.path so signal_bot can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_parse_channel_four.py
+++ b/tests/test_parse_channel_four.py
@@ -1,0 +1,45 @@
+import pytest
+from signal_bot import parse_channel_four
+
+# Valid messages that include entry ranges and multiple SL/TP styles
+VALID_SIGNALS = [
+    (
+        """#XAUUSD\nSell Limit\nEntry Range: 1930 - 1935\nTP1: 1920\nTP2: 1910\nSL: 1940\n""",
+        """\
+📊 #XAUUSD\n📉 Position: Sell Limit\n💲 Entry Price : 1930\n🎯 Entry Range : 1930 – 1935\n✔️ TP1 : 1920\n✔️ TP2 : 1910\n🚫 Stop Loss : 1940""",
+    ),
+    (
+        """#EURUSD\nBuy\nEntry: 1.0800-1.0810\nTake Profit 1 : 1.0850\nTake Profit 2 : 1.0900\nStop Loss : 1.0780\n""",
+        """\
+📊 #EURUSD\n📉 Position: Buy\n💲 Entry Price : 1.0800\n🎯 Entry Range : 1.0800 – 1.0810\n✔️ TP1 : 1.0850\n✔️ TP2 : 1.0900\n🚫 Stop Loss : 1.0780""",
+    ),
+]
+
+# Invalid messages or edge cases
+INVALID_SIGNALS = [
+    # Missing SL
+    """#XAUUSD\nSell\nEntry Range: 1930-1935\nTP1: 1920\nTP2: 1910\n""",
+    # Reversed TP direction (buy but TP below entry)
+    """#EURUSD\nBuy\nEntry Range: 1.0800-1.0810\nTP1: 1.0700\nTP2: 1.0600\nSL: 1.0750\n""",
+]
+
+# Noise messages that should be ignored
+NOISE_MESSAGES = [
+    "TP reached! Great profits",
+    "Move SL to entry",
+]
+
+
+@pytest.mark.parametrize("message,expected", VALID_SIGNALS)
+def test_parse_channel_four_valid(message, expected):
+    assert parse_channel_four(message, 1234) == expected
+
+
+@pytest.mark.parametrize("message", INVALID_SIGNALS)
+def test_parse_channel_four_invalid(message):
+    assert parse_channel_four(message, 1234) is None
+
+
+@pytest.mark.parametrize("message", NOISE_MESSAGES)
+def test_parse_channel_four_noise(message):
+    assert parse_channel_four(message, 1234) is None


### PR DESCRIPTION
## Summary
- extend TP extraction to handle `Take Profit` labels
- implement `parse_channel_four` with entry range support
- add tests covering valid, invalid, and noisy Channel Four messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b41d6da2c48323a880328da7d53e02