### PR TITLE
Improve logging integration with Gunicorn

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -34,3 +34,6 @@ errorlog = "-"
 # Do not preload the app.  Preloading would cause the Telethon event loop
 # to be created in the parent process instead of the worker.
 preload_app = False
+
+# Forward stdout/stderr to Gunicorn logging
+capture_output = True

--- a/signal_bot.py
+++ b/signal_bot.py
@@ -31,8 +31,8 @@ from telethon.sessions import StringSession
 # ----------------------------------------------------------------------------
 # Logging
 # ----------------------------------------------------------------------------
-logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
-log = logging.getLogger("signal-bot")
+log = logging.getLogger("signal_bot")
+log.setLevel(logging.INFO)
 
 # ----------------------------------------------------------------------------
 # Signal parsing (REPLACED / IMPROVED)


### PR DESCRIPTION
## Summary
- Remove global logging.basicConfig and use a module logger set to INFO
- Enable Gunicorn to capture stdout/stderr via `capture_output`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41d6efd248323a22df2a538d25196