### PR TITLE
Compute risk/reward automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a Telegram signal‑forwarding bot designed to run 24/7
 * Compact, unified output format that omits the original source.
 * Web dashboard for configuring API credentials, source/destination channels and for starting/stopping the bot.
 * Automatic reconnection to Telegram if the client disconnects.
+* Automatically computes and displays risk/reward (R/R) ratio when possible.
 
 ## Repository Layout
 
@@ -50,7 +51,7 @@ README.md            # This file
    python app.py
    ```
 
-4. Open http://127.0.0.1:5000 in your browser and fill in your API ID, API hash, session string, source channels and destination channels. Optionally provide channel IDs in **skip_rr_channels** to suppress R/R values for those chats. Click **Start Bot** to begin forwarding.
+4. Open http://127.0.0.1:5000 in your browser and fill in your API ID, API hash, session string, source channels and destination channels. Click **Start Bot** to begin forwarding.
 
 ## Deploying to Render
 
@@ -67,7 +68,6 @@ README.md            # This file
    * `API_HASH` – your Telegram API hash.
    * `SOURCES` – a JSON array of source channel usernames or numeric IDs (e.g. `["@sourceA", -1001234567890]`).
    * `DESTS` – a JSON array of destination channel usernames or numeric IDs.
-   * `SKIP_RR_CHANNELS` – optional JSON array or comma-separated list of channel IDs for which risk/reward should be omitted.
    * `SESSION_STRING` – the session string generated earlier.
 
 5. Deploy the service.  Once running, visit `/` to configure the bot if you have not set environment variables.  The dashboard allows you to start and stop the bot without redeploying.
@@ -76,3 +76,4 @@ README.md            # This file
 
 * Channel identifiers prefixed with `@` are resolved automatically.  Numeric channel IDs (e.g. 1467736193) are coerced to the proper negative format (`-1001467736193`) for Telegram API compatibility.
 * If a source channel has forwarding restrictions enabled, the bot will attempt to copy the content instead of forwarding.  This fallback works for both text messages and media messages.
+* R/R is computed automatically from entry, stop loss and the first take profit if not explicitly provided in the message.

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,8 +26,6 @@
     </div>
     <label>کانال‌های منبع (JSON یا لیست با کاما)</label>
     <textarea name="from_channels" placeholder='[1467736193, 2123816390, 1286609636]'>{{ (cfg.from_channels if cfg else '') or '[1467736193, 2123816390, 1286609636]' }}</textarea>
-    <label>شناسه کانال‌هایی که R/R نمایش داده نشود</label>
-    <input name="skip_rr_channels" placeholder="123456789, -100987654321" value="{{ (cfg.skip_rr_channels if cfg else '') or '' }}">
     <div class="btns">
       <button class="primary" type="submit">ذخیره</button>
     </div>

--- a/tests/test_parse_channel_four.py
+++ b/tests/test_parse_channel_four.py
@@ -6,12 +6,12 @@ VALID_SIGNALS = [
     (
         """#XAUUSD\nSell Limit\nEntry Range: 1930 - 1935\nTP1: 1920\nTP2: 1910\nSL: 1940\n""",
         """\
-📊 #XAUUSD\n📉 Position: Sell Limit\n💲 Entry Price : 1930\n🎯 Entry Range : 1930 – 1935\n✔️ TP1 : 1920\n✔️ TP2 : 1910\n🚫 Stop Loss : 1940""",
+📊 #XAUUSD\n📉 Position: Sell Limit\n❗️ R/R : 1/1\n💲 Entry Price : 1930\n🎯 Entry Range : 1930 – 1935\n✔️ TP1 : 1920\n✔️ TP2 : 1910\n🚫 Stop Loss : 1940""",
     ),
     (
         """#EURUSD\nBuy\nEntry: 1.0800-1.0810\nTake Profit 1 : 1.0850\nTake Profit 2 : 1.0900\nStop Loss : 1.0780\n""",
         """\
-📊 #EURUSD\n📉 Position: Buy\n💲 Entry Price : 1.0800\n🎯 Entry Range : 1.0800 – 1.0810\n✔️ TP1 : 1.0850\n✔️ TP2 : 1.0900\n🚫 Stop Loss : 1.0780""",
+📊 #EURUSD\n📉 Position: Buy\n❗️ R/R : 1/2.5\n💲 Entry Price : 1.0800\n🎯 Entry Range : 1.0800 – 1.0810\n✔️ TP1 : 1.0850\n✔️ TP2 : 1.0900\n🚫 Stop Loss : 1.0780""",
     ),
 ]
 

--- a/tests/test_rr_auto.py
+++ b/tests/test_rr_auto.py
@@ -1,0 +1,15 @@
+import pytest
+from signal_bot import parse_signal
+
+
+def test_parse_signal_calculates_rr():
+    message = """#XAUUSD\nBuy\nEntry Price : 1900\nTP1 : 1910\nStop Loss : 1895"""
+    expected = (
+        "📊 #XAUUSD\n"
+        "📉 Position: Buy\n"
+        "❗️ R/R : 1/2\n"
+        "💲 Entry Price : 1900\n"
+        "✔️ TP1 : 1910\n"
+        "🚫 Stop Loss : 1895"
+    )
+    assert parse_signal(message, 1234) == expected


### PR DESCRIPTION
## Summary
- add `calculate_rr` helper for risk/reward from entry, stop loss and first TP
- compute R/R in `parse_signal` and `parse_channel_four` when message lacks it
- simplify formatting: R/R shown only when available; remove skip list and related config
- document automatic R/R calculation in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b420ed1810832393dce66b5a181b67