### PR TITLE
Refactor SignalBot startup and logging

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: python
     plan: free
     buildCommand: "pip install -r requirements.txt"
-    startCommand: gunicorn -c gunicorn.conf.py wsgi:app
+    startCommand: gunicorn --capture-output --log-level info --error-logfile - --access-logfile - -c gunicorn.conf.py wsgi:app
     envVars:
       - key: PORT
         value: "5000"


### PR DESCRIPTION
## Summary
- initialize structured logging via `setup_logging`
- move blocking start logic into async `_run` with connection status logs
- run Gunicorn with captured stdout/err in Render deployment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4286487188323924d6ffc224629b4