### PR TITLE
Make SignalBot runtime fully asynchronous

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import asyncio
 from threading import Thread
 
 from flask import (
@@ -155,7 +156,7 @@ def start_bot():
 def stop_bot():
     global bot_instance
     if bot_instance and bot_instance.is_running():
-        bot_instance.stop()
+        asyncio.run(bot_instance.stop())
         flash("Bot stopped.", "success")
     else:
         flash("Bot is not running.", "warning")

--- a/signal_bot.py
+++ b/signal_bot.py
@@ -643,13 +643,10 @@ class SignalBot:
         return self._running
 
     # Stop safely (thread-safe on client loop)
-    def stop(self):
+    async def stop(self):
         if self.client:
             try:
-                fut = asyncio.run_coroutine_threadsafe(
-                    self.client.disconnect(), self.client.loop
-                )
-                fut.result(timeout=10)
+                await self.client.disconnect()
                 log.info("Client disconnected.")
             except Exception as e:
                 log.error(f"Error during disconnect: {e}")
@@ -763,7 +760,7 @@ class SignalBot:
                     log.error(f"Handler error: {e}")
 
             try:
-                self.client.start()
+                await self.client.start()
 
                 async def _verify():
                     for c in self.from_channels:
@@ -792,7 +789,7 @@ class SignalBot:
                 log.info("Bot is up...")
                 while self._running:
                     try:
-                        await asyncio.to_thread(self.client.run_until_disconnected)
+                        await self.client.run_until_disconnected()
                     except (ConnectionError, asyncio.TimeoutError):
                         async def _reconnect():
                             retries = 0
@@ -851,7 +848,6 @@ class SignalBot:
         except RuntimeError:
             log.info("SignalBot running standalone event loop.")
             asyncio.run(self._run())
-        self._running = True
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -19,13 +19,13 @@ def test_reconnect_loop_continues_on_failure():
                 return func
             return decorator
 
-        def start(self):
+        async def start(self):
             pass
 
         async def get_entity(self, c):
             return SimpleNamespace(title='dummy', id=c)
 
-        def run_until_disconnected(self):
+        async def run_until_disconnected(self):
             run_calls['count'] += 1
             raise ConnectionError('network down')
 
@@ -66,13 +66,13 @@ def test_reconnect_success_uses_same_client():
                 return func
             return decorator
 
-        def start(self):
+        async def start(self):
             pass
 
         async def get_entity(self, c):
             return SimpleNamespace(title='dummy', id=c)
 
-        def run_until_disconnected(self):
+        async def run_until_disconnected(self):
             run_calls['count'] += 1
             if run_calls['count'] == 1:
                 raise ConnectionError('network down')


### PR DESCRIPTION
## Summary
- await client startup and disconnection operations
- run the Telegram client directly in the event loop instead of a worker thread
- expose async stop and adjust web layer/test doubles accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42c2332d08323a62a30cf353a3b24