### PR TITLE
Normalize digit-only channel identifiers

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -565,10 +565,17 @@ def _content_fingerprint(ev_msg, chat_id: int) -> str:
 def _norm_chat_identifier(x: Union[int, str]) -> Union[int, str]:
     """Normalise channel identifiers: '@name' / 'https://t.me/name' / numeric."""
     if isinstance(x, int):
-        return x
+        # Ensure numeric identifiers are coerced to Telegram channel IDs
+        return _coerce_channel_id(x)
+
     s = (x or "").strip()
     s = re.sub(r"^https?://t\.me/", "", s, flags=re.IGNORECASE)
     s = s.lstrip("@").strip()
+
+    # If the remaining string is purely numeric, convert to int and coerce
+    if re.fullmatch(r"-?\d+", s):
+        return _coerce_channel_id(int(s))
+
     return s
 
 
@@ -576,6 +583,10 @@ def _coerce_channel_id(x: Union[int, str]) -> Union[int, str]:
     """Coerce positive numeric IDs to Telegram channel form -100XXXXXXXXXX."""
     if isinstance(x, int):
         return x if x < 0 else int("-100" + str(x))
+
+    if isinstance(x, str) and re.fullmatch(r"\d+", x):
+        return int("-100" + x)
+
     return x
 
 

--- a/tests/test_norm_chat_identifier.py
+++ b/tests/test_norm_chat_identifier.py
@@ -1,0 +1,24 @@
+import pytest
+from signal_bot import _norm_chat_identifier, SignalBot
+
+
+def test_norm_chat_identifier_numeric_string():
+    assert _norm_chat_identifier("12345") == -10012345
+
+
+def test_norm_chat_identifier_negative_string():
+    assert _norm_chat_identifier("-10012345") == -10012345
+
+
+def test_norm_chat_identifier_username():
+    assert _norm_chat_identifier("@mychannel") == "mychannel"
+
+
+def test_norm_chat_identifier_url_numeric():
+    assert _norm_chat_identifier("https://t.me/12345") == -10012345
+
+
+def test_signalbot_normalizes_string_ids():
+    bot = SignalBot(1, "hash", "session", ["12345"], ["67890"])
+    assert bot.from_channels == [-10012345]
+    assert bot.to_channels == [-10067890]


### PR DESCRIPTION
## Summary
- normalize digit-only channel identifiers by converting strings to integers and coercing Telegram's `-100` prefix
- extend `_coerce_channel_id` to accept numeric strings
- test normalization of string IDs directly and during `SignalBot` setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42c2404c4832385512da215c611f6