### PR TITLE
Handle invalid api_id in start_bot

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,11 +135,17 @@ def start_bot():
         return redirect(url_for("index"))
 
     # Parse sources and destinations
+    try:
+        api_id_int = int(cfg.get("api_id"))
+    except (TypeError, ValueError):
+        flash("API ID must be an integer.", "error")
+        return render_template("index.html", cfg=cfg), 400
+
     from_channels = parse_from_channels(cfg.get("from_channels"))
     to_channels = parse_to_channels(cfg.get("to_channels"))
 
     bot_instance = SignalBot(
-        api_id=int(cfg.get("api_id")),
+        api_id=api_id_int,
         api_hash=cfg.get("api_hash"),
         session_string=cfg.get("session_string") or "",
         from_channels=from_channels,

--- a/tests/test_invalid_api_id.py
+++ b/tests/test_invalid_api_id.py
@@ -1,0 +1,31 @@
+import importlib
+
+
+def test_start_bot_invalid_api_id(monkeypatch):
+    """Posting to /start_bot with a non-int api_id returns 400 and flashes."""
+    monkeypatch.setenv("SESSION_SECRET", "test")
+    app = importlib.reload(importlib.import_module("app"))
+
+    # Populate config with required fields but invalid api_id
+    app.config_store.update(
+        {
+            "api_id": "notanint",
+            "api_hash": "hash",
+            "session_string": "session",
+            "from_channels": "",
+            "to_channels": "dest",
+        }
+    )
+    app.bot_instance = None
+
+    with app.app.test_client() as client:
+        response = client.post("/start_bot")
+        assert response.status_code == 400
+        with client.session_transaction() as sess:
+            flashes = sess.get("_flashes", [])
+        assert any(
+            category == "error" and "API ID must be an integer." in msg
+            for category, msg in flashes
+        )
+    assert app.bot_instance is None
+


### PR DESCRIPTION
## Summary
- guard `start_bot` from non-integer API ID values and return a 400 with flash message
- add test verifying the route handles invalid API ID gracefully

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42c24927c83238bef80af381d9a06