### PR TITLE
Add basic authentication to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ README.md            # This file
 
 4. Open http://127.0.0.1:5000 in your browser and fill in your API ID, API hash, session string, source channels and destination channels. Click **Start Bot** to begin forwarding.
 
+## Authentication
+
+The dashboard is protected by a simple login. Before running the app set
+the following environment variables:
+
+* `SESSION_SECRET` – random string used to sign the Flask session.
+* `ADMIN_USER` – username for logging in.
+* `ADMIN_PASS` – password for logging in.
+
+Visit `/login` and enter the credentials to access protected routes like
+`/`, `/save_config`, `/start_bot` and `/stop_bot`.
+
 ## Deploying to Render
 
 1. Push this repository (without your session string) to GitHub.
@@ -69,6 +81,9 @@ README.md            # This file
    * `SOURCES` – a JSON array of source channel usernames or numeric IDs (e.g. `["@sourceA", -1001234567890]`).
    * `DESTS` – a JSON array of destination channel usernames or numeric IDs.
    * `SESSION_STRING` – the session string generated earlier.
+   * `SESSION_SECRET` – random string for Flask session security.
+   * `ADMIN_USER` – username for the web dashboard.
+   * `ADMIN_PASS` – password for the web dashboard.
 
 5. Deploy the service.  Once running, visit `/` to configure the bot if you have not set environment variables.  The dashboard allows you to start and stop the bot without redeploying.
 

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ import os
 import re
 import asyncio
 from threading import Thread
+from functools import wraps
 
 from flask import (
     Flask,
@@ -21,6 +22,7 @@ from flask import (
     redirect,
     render_template,
     request,
+    session,
     url_for,
 )
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -38,6 +40,11 @@ secret = os.environ.get("SESSION_SECRET")
 if not secret:
     raise RuntimeError("SESSION_SECRET environment variable must be set")
 app.secret_key = secret
+
+admin_user = os.environ.get("ADMIN_USER")
+admin_pass = os.environ.get("ADMIN_PASS")
+if not admin_user or not admin_pass:
+    raise RuntimeError("ADMIN_USER and ADMIN_PASS must be set")
 
 app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
@@ -90,16 +97,46 @@ def parse_to_channels(raw: str | None) -> list:
 
 
 # ----------------------------------------------------------------------------
+# Authentication
+# ----------------------------------------------------------------------------
+
+
+def login_required(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not session.get("logged_in"):
+            return redirect(url_for("login"))
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username", "")
+        password = request.form.get("password", "")
+        if username == admin_user and password == admin_pass:
+            session["logged_in"] = True
+            flash("Logged in.", "success")
+            return redirect(url_for("index"))
+        flash("Invalid credentials.", "error")
+    return render_template("login.html")
+
+
+# ----------------------------------------------------------------------------
 # Routes
 # ----------------------------------------------------------------------------
 
 @app.route("/", methods=["GET"])
+@login_required
 def index():
     cfg = config_store
     return render_template("index.html", cfg=cfg)
 
 
 @app.route("/save_config", methods=["POST"])
+@login_required
 def save_config():
     api_id = request.form.get("api_id", "").strip()
     api_hash = request.form.get("api_hash", "").strip()
@@ -121,6 +158,7 @@ def save_config():
 
 
 @app.route("/start_bot", methods=["POST"])
+@login_required
 def start_bot():
     global bot_instance
     cfg = config_store
@@ -159,6 +197,7 @@ def start_bot():
 
 
 @app.route("/stop_bot", methods=["POST"])
+@login_required
 def stop_bot():
     global bot_instance
     if bot_instance and bot_instance.is_running():

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  <label>Username</label>
+  <input name="username" required>
+  <label>Password</label>
+  <input name="password" type="password" required>
+  <div class="btns">
+    <button type="submit">Login</button>
+  </div>
+</form>
+{% endblock %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,19 @@
+import importlib
+
+
+def _load_app(monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET", "test")
+    monkeypatch.setenv("ADMIN_USER", "u")
+    monkeypatch.setenv("ADMIN_PASS", "p")
+    return importlib.reload(importlib.import_module("app"))
+
+
+def test_login_required(monkeypatch):
+    app = _load_app(monkeypatch)
+    with app.app.test_client() as client:
+        resp = client.get("/")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+        client.post("/login", data={"username": "u", "password": "p"})
+        resp = client.get("/")
+        assert resp.status_code == 200

--- a/tests/test_invalid_api_id.py
+++ b/tests/test_invalid_api_id.py
@@ -4,6 +4,8 @@ import importlib
 def test_start_bot_invalid_api_id(monkeypatch):
     """Posting to /start_bot with a non-int api_id returns 400 and flashes."""
     monkeypatch.setenv("SESSION_SECRET", "test")
+    monkeypatch.setenv("ADMIN_USER", "u")
+    monkeypatch.setenv("ADMIN_PASS", "p")
     app = importlib.reload(importlib.import_module("app"))
 
     # Populate config with required fields but invalid api_id
@@ -19,6 +21,7 @@ def test_start_bot_invalid_api_id(monkeypatch):
     app.bot_instance = None
 
     with app.app.test_client() as client:
+        client.post("/login", data={"username": "u", "password": "p"})
         response = client.post("/start_bot")
         assert response.status_code == 400
         with client.session_transaction() as sess:


### PR DESCRIPTION
## Summary
- require `ADMIN_USER`/`ADMIN_PASS` environment credentials and add a login route storing a session flag
- protect control routes with a session-based `login_required` decorator
- document authentication and new environment variables in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b430ec61f8832395b1f95c4999157b