### PR TITLE
Reject mismatched TP directions

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -394,13 +394,14 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Optional[str]:
     # sanity check: ensure TPs are in correct direction
     try:
         e = float(entry)
-        tp_vals = [float(tp) for tp in tps]
-        if position.upper().startswith("SELL") and any(tp > e for tp in tp_vals):
-            log.info("IGNORED (sell but TP > entry)")
-            return None
-        if position.upper().startswith("BUY") and any(tp < e for tp in tp_vals):
-            log.info("IGNORED (buy but TP < entry)")
-            return None
+        for tp in tps:
+            tv = float(tp)
+            if position.upper().startswith("SELL") and tv > e:
+                log.info(f"IGNORED (sell but TP {tp} > entry {entry})")
+                return None
+            if position.upper().startswith("BUY") and tv < e:
+                log.info(f"IGNORED (buy but TP {tp} < entry {entry})")
+                return None
     except Exception:
         pass
 
@@ -456,13 +457,13 @@ def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
 
     try:
         e = float(entry)
-        if position.upper().startswith("SELL"):
-            if all(float(tp) > e for tp in tps):
-                log.info("IGNORED (sell but all TP > entry)")
+        for tp in tps:
+            tv = float(tp)
+            if position.upper().startswith("SELL") and tv > e:
+                log.info(f"IGNORED (sell but TP {tp} > entry {entry})")
                 return None
-        if position.upper().startswith("BUY"):
-            if all(float(tp) < e for tp in tps):
-                log.info("IGNORED (buy but all TP < entry)")
+            if position.upper().startswith("BUY") and tv < e:
+                log.info(f"IGNORED (buy but TP {tp} < entry {entry})")
                 return None
     except Exception:
         pass
@@ -515,13 +516,13 @@ def parse_signal(text: str, chat_id: int) -> Optional[str]:
     # sanity check: جهت TPها با Entry همخوان باشد
     try:
         e = float(entry)
-        if position.upper().startswith("SELL"):
-            if all(float(tp) > e for tp in tps):
-                log.info("IGNORED (sell but all TP > entry)")
+        for tp in tps:
+            tv = float(tp)
+            if position.upper().startswith("SELL") and tv > e:
+                log.info(f"IGNORED (sell but TP {tp} > entry {entry})")
                 return None
-        if position.upper().startswith("BUY"):
-            if all(float(tp) < e for tp in tps):
-                log.info("IGNORED (buy but all TP < entry)")
+            if position.upper().startswith("BUY") and tv < e:
+                log.info(f"IGNORED (buy but TP {tp} < entry {entry})")
                 return None
     except Exception:
         pass

--- a/tests/test_parse_channel_four.py
+++ b/tests/test_parse_channel_four.py
@@ -21,6 +21,10 @@ INVALID_SIGNALS = [
     """#XAUUSD\nSell\nEntry Range: 1930-1935\nTP1: 1920\nTP2: 1910\n""",
     # Reversed TP direction (buy but TP below entry)
     """#EURUSD\nBuy\nEntry Range: 1.0800-1.0810\nTP1: 1.0700\nTP2: 1.0600\nSL: 1.0750\n""",
+    # Mixed TP directions (sell with TP above entry)
+    """#XAUUSD\nSell Limit\nEntry Range: 1930 - 1935\nTP1: 1920\nTP2: 1940\nSL: 1945\n""",
+    # Mixed TP directions (buy with TP below entry)
+    """#EURUSD\nBuy\nEntry Range: 1.0800-1.0810\nTP1: 1.0850\nTP2: 1.0700\nSL: 1.0750\n""",
 ]
 
 # Noise messages that should be ignored

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -12,6 +12,10 @@ VALID_SIGNALS = [
 
 INVALID_SIGNALS = [
     """#XAUUSD\nBuy\nEntry Price: 1932\nStop Loss: 1925""",  # Missing TP
+    # Mixed TP directions (buy with TP below entry)
+    """#XAUUSD\nBuy\nEntry Price : 1900\nTP1 : 1910\nTP2 : 1890\nStop Loss : 1895\n""",
+    # Mixed TP directions (sell with TP above entry)
+    """#XAUUSD\nSell\nEntry Price : 1900\nTP1 : 1890\nTP2 : 1910\nStop Loss : 1915\n""",
 ]
 
 NOISE_MESSAGES = [


### PR DESCRIPTION
## Summary
- Reject signals when any TP contradicts trade direction
- Clarify rejection logs with offending TP values
- Test mixed-direction TP scenarios for buy and sell signals

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b430ed9e78832390828326187a0fd6