### PR TITLE
Add admin credentials to Render configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,3 +10,7 @@ services:
         value: "5000"
       - key: SESSION_SECRET
         sync: false
+      - key: ADMIN_USER
+        sync: false
+      - key: ADMIN_PASS
+        sync: false


### PR DESCRIPTION
## Summary
- declare ADMIN_USER and ADMIN_PASS variables in render.yaml for deployment

## Testing
- `ADMIN_USER=admin ADMIN_PASS=pass pytest` *(fails: tests/test_stop_bot.py::test_stop_bot_route_disconnects_cleanly)*

------
https://chatgpt.com/codex/tasks/task_e_68b434d6ded88323b9d6edce959e7c45