### PR TITLE
Add profile manager UI and REST APIs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
+<div class="toolbar" style="margin-bottom:16px;">
+  <a href="{{ url_for('profiles_page') }}"><button class="secondary">مدیریت پروفایل‌ها</button></a>
+</div>
 <div class="card">
   <h2>تنظیمات</h2>
   <form method="post" action="{{ url_for('save_config') }}">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>{{ 'ویرایش پروفایل' if profile else 'ایجاد پروفایل' }}</h2>
+<form id="profileForm">
+  <label>نام پروفایل</label>
+  <input name="name" value="{{ profile.name if profile else '' }}" {{ 'readonly' if profile else '' }} required>
+  <label>کانال‌های منبع</label>
+  <textarea name="from_channels" placeholder='[@src1, -10012345]'>{{ profile.from_channels|join(', ') if profile else '' }}</textarea>
+  <label>کانال‌های مقصد</label>
+  <textarea name="to_channels" placeholder='[@dest1, @dest2]'>{{ profile.to_channels|join(', ') if profile else '' }}</textarea>
+  <label>گزینه‌های پارس</label>
+  <input name="parse_options" value="{{ profile.parse_options if profile else '' }}">
+  <div class="btns">
+    <button class="primary" type="submit">ذخیره</button>
+  </div>
+</form>
+
+{% if profile %}
+<h3>تست پیام نمونه</h3>
+<textarea id="sampleText" placeholder="پیام برای تست"></textarea>
+<button id="testBtn">تست</button>
+<pre id="testResult"></pre>
+{% endif %}
+
+<script>
+const form = document.getElementById('profileForm');
+if(form){
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(form).entries());
+    data.from_channels = data.from_channels ? data.from_channels.split(/[,\s]+/).filter(Boolean) : [];
+    data.to_channels = data.to_channels ? data.to_channels.split(/[,\s]+/).filter(Boolean) : [];
+    const method = "{{ 'PUT' if profile else 'POST' }}";
+    const url = "{{ url_for('api_profile', name=profile.name) if profile else url_for('api_profiles') }}";
+    const res = await fetch(url, {
+      method: method,
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(data)
+    });
+    if(res.ok){
+      alert('Saved');
+      if(method === 'POST'){
+        location.href = '/profiles/' + data.name;
+      }
+    }else{
+      const j = await res.json().catch(()=>({}));
+      alert(j.error || 'Error');
+    }
+  });
+}
+
+const testBtn = document.getElementById('testBtn');
+if(testBtn){
+  testBtn.addEventListener('click', async () => {
+    const msg = document.getElementById('sampleText').value;
+    const res = await fetch("{{ url_for('api_profile_test', name=profile.name if profile else '') }}", {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({message: msg})
+    });
+    const j = await res.json();
+    document.getElementById('testResult').innerText = j.parsed || j.error || '';
+  });
+}
+</script>
+{% endblock %}

--- a/templates/profiles.html
+++ b/templates/profiles.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>پروفایل‌ها</h2>
+<div class="toolbar">
+  <a href="{{ url_for('new_profile_page') }}"><button class="primary">پروفایل جدید</button></a>
+</div>
+<div style="margin-top:12px;">
+  {% for p in profiles.values() %}
+    <div class="pill"><a href="{{ url_for('edit_profile_page', name=p.name) }}">{{ p.name }}</a></div>
+  {% else %}
+    <p>پروفایلی موجود نیست.</p>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add in-memory profile store and routes for profile management
- build profile creation/editing templates with channel and parse options and sample message test
- expose RESTful API endpoints for CRUD operations and message parsing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b434b53aa08323b0c6de3c2738e1e4