### PR TITLE
Add Jinja2 templating and profile-based routing

### DIFF
--- a/tests/test_parse_channel_numbers.py
+++ b/tests/test_parse_channel_numbers.py
@@ -5,6 +5,8 @@ import pytest
 @pytest.fixture
 def app_module(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
+    monkeypatch.setenv("ADMIN_USER", "u")
+    monkeypatch.setenv("ADMIN_PASS", "p")
     return importlib.reload(importlib.import_module("app"))
 
 

--- a/tests/test_profile_mapping.py
+++ b/tests/test_profile_mapping.py
@@ -1,0 +1,17 @@
+from signal_bot import SignalBot
+
+
+def test_resolve_targets_with_profile_mapping():
+    profiles = {
+        "default": {
+            111: {"dests": [222], "template": "prefix {{ message }}"}
+        }
+    }
+    bot = SignalBot(1, "hash", "session", [111], [333], profiles=profiles)
+    dests, template = bot.resolve_targets(111)
+    assert dests == [-100222]
+    assert template == "prefix {{ message }}"
+
+    dests_default, template_default = bot.resolve_targets(999)
+    assert dests_default == [-100333]
+    assert template_default is None

--- a/tests/test_stop_bot.py
+++ b/tests/test_stop_bot.py
@@ -5,6 +5,8 @@ import importlib
 
 def test_stop_bot_route_disconnects_cleanly(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
+    monkeypatch.setenv("ADMIN_USER", "u")
+    monkeypatch.setenv("ADMIN_PASS", "p")
     app = importlib.import_module("app")
 
     loop = asyncio.new_event_loop()
@@ -38,6 +40,8 @@ def test_stop_bot_route_disconnects_cleanly(monkeypatch):
     monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_run_coroutine_threadsafe)
 
     client = app.app.test_client()
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
     resp = client.post("/stop_bot")
     assert resp.status_code == 302
     assert fake_bot.stopped

--- a/tests/test_template_render.py
+++ b/tests/test_template_render.py
@@ -1,0 +1,7 @@
+from signal_bot import render_template
+
+
+def test_render_template_basic():
+    template = "Hello {{ name }}"
+    result = render_template(template, {"name": "Alice"})
+    assert result == "Hello Alice"


### PR DESCRIPTION
## Summary
- Render messages using Jinja2 templates
- Map source channels to destinations and templates via profiles
- Exercise new templating and profile logic in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b434b4715c83238f441408864ecf2a