### PR TITLE
Add profile-based signal parsing with entry range support

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -32,7 +32,7 @@ import hashlib
 import time
 from datetime import datetime, timezone, timedelta
 from collections import deque
-from typing import List, Dict, Optional, Iterable, Callable, Union, Deque, Tuple
+from typing import List, Dict, Optional, Iterable, Callable, Union, Deque, Tuple, Any
 
 from telethon import TelegramClient, events
 from telethon.errors import (
@@ -102,6 +102,17 @@ UK_NOISE_LINES = [
     re.compile(r"sl\s+(?:hit|reached)", re.IGNORECASE),
     re.compile(r"result", re.IGNORECASE),
 ]
+
+# General entry range detector
+ENTRY_RANGE_RE = re.compile(r"(-?\d+(?:\.\d+)?)[^0-9]+(-?\d+(?:\.\d+)?)")
+
+# Mapping of chat IDs to profile options controlling parsing behaviour.
+CHANNEL_PROFILES: Dict[int, Dict[str, Any]] = {}
+
+
+def resolve_profile(chat_id: int) -> Dict[str, Any]:
+    """Return the profile dict associated with a chat ID."""
+    return CHANNEL_PROFILES.get(int(chat_id), {})
 
 
 def _norm(s: str) -> str:
@@ -254,6 +265,14 @@ def is_valid(signal: Dict) -> bool:
         signal.get("entry"),
         signal.get("sl"),
     ]) and len(signal.get("tps", [])) >= 1
+
+
+def has_entry_range(lines: List[str]) -> bool:
+    """Detect whether any line contains an entry range."""
+    for l in lines:
+        if "entry" in l.lower() and ENTRY_RANGE_RE.search(l):
+            return True
+    return False
 
 
 def to_unified(signal: Dict, chat_id: int, extra: Optional[Dict] = None) -> str:
@@ -470,7 +489,8 @@ def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
 
     return to_unified(signal, chat_id, signal.get("extra", {}))
 
-def parse_signal(text: str, chat_id: int) -> Optional[str]:
+def parse_signal(text: str, chat_id: int, profile: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    profile = profile or {}
     text = normalize_numbers(text)
     # Special-case: United Kings parser
     if chat_id in UNITED_KINGS_CHAT_IDS or _looks_like_united_kings(text):
@@ -490,6 +510,18 @@ def parse_signal(text: str, chat_id: int) -> Optional[str]:
     if not lines:
         log.info("IGNORED (empty)")
         return None
+
+    if has_entry_range(lines):
+        if profile.get("allow_entry_range"):
+            try:
+                res = parse_channel_four(text, chat_id)
+                if res is not None:
+                    return res
+            except Exception as e:
+                log.debug(f"Entry range parser failed: {e}")
+        else:
+            log.info("IGNORED (entry range not allowed)")
+            return None
 
     symbol = guess_symbol(text) or ""
     position = guess_position(text) or ""
@@ -751,7 +783,8 @@ class SignalBot:
                     if self._dedup_and_remember(int(event.chat_id), event.message):
                         return
 
-                    formatted = parse_signal(text, event.chat_id)
+                    profile = resolve_profile(int(event.chat_id))
+                    formatted = parse_signal(text, event.chat_id, profile)
                     if not formatted:
                         return
 

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -25,14 +25,14 @@ NOISE_MESSAGES = [
 
 @pytest.mark.parametrize("message,expected", VALID_SIGNALS)
 def test_parse_united_kings_valid(message, expected):
-    assert parse_signal(message, 1234) == expected
+    assert parse_signal(message, 1234, {}) == expected
 
 
 @pytest.mark.parametrize("message", INVALID_SIGNALS)
 def test_parse_united_kings_invalid(message):
-    assert parse_signal(message, 1234) is None
+    assert parse_signal(message, 1234, {}) is None
 
 
 @pytest.mark.parametrize("message", NOISE_MESSAGES)
 def test_parse_united_kings_noise(message):
-    assert parse_signal(message, 1234) is None
+    assert parse_signal(message, 1234, {}) is None

--- a/tests/test_profile_entry_range.py
+++ b/tests/test_profile_entry_range.py
@@ -1,0 +1,15 @@
+import pytest
+from signal_bot import parse_signal, parse_channel_four
+
+MESSAGE = """#XAUUSD\nSell Limit\nEntry Range: 1930 - 1935\nTP1: 1920\nTP2: 1910\nSL: 1940\n"""
+
+
+def test_parse_signal_respects_allow_entry_range_true():
+    profile = {"allow_entry_range": True}
+    expected = parse_channel_four(MESSAGE, 1234)
+    assert parse_signal(MESSAGE, 1234, profile) == expected
+
+
+def test_parse_signal_rejects_entry_range_when_not_allowed():
+    profile = {}
+    assert parse_signal(MESSAGE, 1234, profile) is None

--- a/tests/test_rr_auto.py
+++ b/tests/test_rr_auto.py
@@ -12,4 +12,4 @@ def test_parse_signal_calculates_rr():
         "✔️ TP1 : 1910\n"
         "🚫 Stop Loss : 1895"
     )
-    assert parse_signal(message, 1234) == expected
+    assert parse_signal(message, 1234, {}) == expected


### PR DESCRIPTION
## Summary
- Map chat IDs to profile options and resolve profiles before parsing
- Extend `parse_signal` to accept a profile and honor `allow_entry_range`
- Add tests for profile-controlled entry range parsing

## Testing
- `ADMIN_USER=u ADMIN_PASS=p pytest` *(fails: tests/test_stop_bot.py::test_stop_bot_route_disconnects_cleanly - assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68b434b3c1c88323a8bd3af7abfdd38f