### PR TITLE
Require login for stopping bot

### DIFF
--- a/app.py
+++ b/app.py
@@ -335,6 +335,7 @@ def start_bot():
 
 
 @app.route("/stop_bot", methods=["POST"])
+@login_required
 def stop_bot():
     global bot_instance
     if bot_instance and bot_instance.is_running():

--- a/tests/test_stop_bot.py
+++ b/tests/test_stop_bot.py
@@ -3,11 +3,15 @@ from concurrent.futures import Future
 import importlib
 
 
-def test_stop_bot_route_disconnects_cleanly(monkeypatch):
+def _load_app(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
-    app = importlib.import_module("app")
+    return importlib.reload(importlib.import_module("app"))
+
+
+def test_stop_bot_route_disconnects_cleanly(monkeypatch):
+    app = _load_app(monkeypatch)
 
     loop = asyncio.new_event_loop()
 
@@ -15,8 +19,10 @@ def test_stop_bot_route_disconnects_cleanly(monkeypatch):
         def __init__(self, loop):
             self.loop = loop
             self.stopped = False
+
         def is_running(self):
             return True
+
         async def stop(self):
             self.stopped = True
 
@@ -37,7 +43,9 @@ def test_stop_bot_route_disconnects_cleanly(monkeypatch):
             fut.set_result(result)
         return fut
 
-    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_run_coroutine_threadsafe)
+    monkeypatch.setattr(
+        asyncio, "run_coroutine_threadsafe", fake_run_coroutine_threadsafe
+    )
 
     client = app.app.test_client()
     with client.session_transaction() as sess:
@@ -47,4 +55,12 @@ def test_stop_bot_route_disconnects_cleanly(monkeypatch):
     assert fake_bot.stopped
     assert calls["count"] == 1
     loop.close()
+
+
+def test_stop_bot_requires_login(monkeypatch):
+    app = _load_app(monkeypatch)
+    client = app.app.test_client()
+    resp = client.post("/stop_bot")
+    assert resp.status_code == 302
+    assert "/login" in resp.headers["Location"]
 


### PR DESCRIPTION
## Summary
- secure `/stop_bot` route with authentication
- cover unauthorized stop bot access with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43fab851c8323ae6262bd89cff34a