### PR TITLE
Add CSRF protection using itsdangerous

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.3
 telethon==1.36.0
 gunicorn==22.0.0
+itsdangerous==2.2.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="csrf-token" content="{{ csrf_token() }}" />
   <title>Trade Signal Bot</title>
   <style>
     body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;background:#0b0d12;color:#e8eaf0;margin:0}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,7 @@
 <div class="card">
   <h2>تنظیمات</h2>
   <form method="post" action="{{ url_for('save_config') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <div class="row">
       <div class="col-6">
         <label>API ID</label>
@@ -38,9 +39,11 @@
 <div class="card">
   <h2>کنترل ربات</h2>
   <form method="post" action="{{ url_for('start_bot') }}" style="display:inline">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <button class="primary">Start Bot</button>
   </form>
   <form method="post" action="{{ url_for('stop_bot') }}" style="display:inline">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
     <button>Stop Bot</button>
   </form>
   <div style="margin-top:8px;">

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>Login</h2>
 <form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
   <label>Username</label>
   <input name="username" required>
   <label>Password</label>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -24,6 +24,7 @@
 
 <script>
 const form = document.getElementById('profileForm');
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 if(form){
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -34,7 +35,7 @@ if(form){
     const url = "{{ url_for('api_profile', name=profile.name) if profile else url_for('api_profiles') }}";
     const res = await fetch(url, {
       method: method,
-      headers: {'Content-Type': 'application/json'},
+      headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
       body: JSON.stringify(data)
     });
     if(res.ok){
@@ -55,7 +56,7 @@ if(testBtn){
     const msg = document.getElementById('sampleText').value;
     const res = await fetch("{{ url_for('api_profile_test', name=profile.name if profile else '') }}", {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+      headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
       body: JSON.stringify({message: msg})
     });
     const j = await res.json();

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,9 @@ def _load_app(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
-    return importlib.reload(importlib.import_module("app"))
+    app = importlib.reload(importlib.import_module("app"))
+    app.app.config["WTF_CSRF_ENABLED"] = False
+    return app
 
 
 def test_login_required(monkeypatch):

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,28 @@
+import importlib
+import pytest
+
+
+def _load_app(monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET", "test")
+    app = importlib.reload(importlib.import_module("app"))
+    return app
+
+
+@pytest.mark.parametrize(
+    "url, method, kwargs",
+    [
+        ("/save_config", "post", {}),
+        ("/start_bot", "post", {}),
+        ("/stop_bot", "post", {}),
+        ("/api/profiles", "post", {"json": {"name": "p"}}),
+        ("/api/profiles/demo/test", "post", {"json": {"message": "hi"}}),
+    ],
+)
+def test_missing_csrf_rejected(monkeypatch, url, method, kwargs):
+    app = _load_app(monkeypatch)
+    with app.app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["logged_in"] = True
+        resp = getattr(client, method)(url, **kwargs)
+        assert resp.status_code == 400
+

--- a/tests/test_invalid_api_id.py
+++ b/tests/test_invalid_api_id.py
@@ -7,6 +7,7 @@ def test_start_bot_invalid_api_id(monkeypatch):
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
     app = importlib.reload(importlib.import_module("app"))
+    app.app.config["WTF_CSRF_ENABLED"] = False
 
     # Populate config with required fields but invalid api_id
     app.config_store.update(

--- a/tests/test_stop_bot.py
+++ b/tests/test_stop_bot.py
@@ -7,7 +7,8 @@ def test_stop_bot_route_disconnects_cleanly(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
-    app = importlib.import_module("app")
+    app = importlib.reload(importlib.import_module("app"))
+    app.app.config["WTF_CSRF_ENABLED"] = False
 
     loop = asyncio.new_event_loop()
 


### PR DESCRIPTION
## Summary
- Implement CSRF token generation/validation with itsdangerous
- Embed CSRF tokens in HTML forms and AJAX requests
- Add tests ensuring POST endpoints reject missing tokens

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b43fad1fb08323b7adcdfa70f574df