### PR TITLE
Handle comma thousands separators in normalize_numbers

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -134,6 +134,7 @@ def normalize_numbers(text: str) -> str:
     # Normalize decimal and thousands separators
     trans[ord("٫")] = "."  # Arabic decimal separator
     trans[ord("٬")] = ""  # Arabic thousands separator (remove)
+    trans[ord(",")] = ""  # Comma thousands separator (remove)
 
     return text.translate(trans)
 

--- a/tests/test_normalize_numbers.py
+++ b/tests/test_normalize_numbers.py
@@ -1,0 +1,6 @@
+from signal_bot import normalize_numbers
+
+
+def test_normalize_numbers_removes_commas():
+    assert normalize_numbers("۱۲۳,۴۵۶") == "123456"
+    assert normalize_numbers("1,234") == "1234"


### PR DESCRIPTION
## Summary
- Strip comma thousands separators in `normalize_numbers`.
- Add unit test ensuring comma-separated numerals are normalized.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b44569f3248323a5d3c04557106f0f