### PR TITLE
Safeguard bot stop when loop absent

### DIFF
--- a/app.py
+++ b/app.py
@@ -366,11 +366,13 @@ def start_bot():
 @app.route("/stop_bot", methods=["POST"])
 def stop_bot():
     global bot_instance
-    if bot_instance and bot_instance.is_running():
+    if not bot_instance or not bot_instance.is_running():
+        flash("Bot is not running.", "warning")
+    elif not getattr(bot_instance, "loop", None) or not bot_instance.loop.is_running():
+        flash("Bot loop is not running.", "warning")
+    else:
         asyncio.run_coroutine_threadsafe(bot_instance.stop(), bot_instance.loop)
         flash("Bot stopped.", "success")
-    else:
-        flash("Bot is not running.", "warning")
     return redirect(url_for("index"))
 
 

--- a/tests/test_stop_bot.py
+++ b/tests/test_stop_bot.py
@@ -10,7 +10,11 @@ def test_stop_bot_route_disconnects_cleanly(monkeypatch):
     app = importlib.reload(importlib.import_module("app"))
     app.app.config["WTF_CSRF_ENABLED"] = False
 
-    loop = asyncio.new_event_loop()
+    class DummyLoop:
+        def is_running(self):
+            return True
+
+    loop = DummyLoop()
 
     class FakeBot:
         def __init__(self, loop):
@@ -31,7 +35,7 @@ def test_stop_bot_route_disconnects_cleanly(monkeypatch):
         assert loop_arg is loop
         fut = Future()
         try:
-            result = loop.run_until_complete(coro)
+            result = asyncio.run(coro)
         except Exception as e:
             fut.set_exception(e)
         else:
@@ -47,5 +51,37 @@ def test_stop_bot_route_disconnects_cleanly(monkeypatch):
     assert resp.status_code == 302
     assert fake_bot.stopped
     assert calls["count"] == 1
-    loop.close()
+
+
+def test_stop_bot_no_loop_does_not_crash(monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET", "test")
+    monkeypatch.setenv("ADMIN_USER", "u")
+    monkeypatch.setenv("ADMIN_PASS", "p")
+    app = importlib.reload(importlib.import_module("app"))
+    app.app.config["WTF_CSRF_ENABLED"] = False
+
+    class FakeBot:
+        loop = None
+        def is_running(self):
+            return True
+        async def stop(self):
+            raise AssertionError("stop should not be awaited")
+
+    fake_bot = FakeBot()
+    monkeypatch.setattr(app, "bot_instance", fake_bot)
+
+    calls = {"count": 0}
+
+    def fake_run_coroutine_threadsafe(*args, **kwargs):
+        calls["count"] += 1
+        raise AssertionError("run_coroutine_threadsafe should not be called")
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_run_coroutine_threadsafe)
+
+    client = app.app.test_client()
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
+    resp = client.post("/stop_bot")
+    assert resp.status_code == 302
+    assert calls["count"] == 0
 


### PR DESCRIPTION
## Summary
- validate bot instance and its event loop before stopping, warning when inactive
- test stopping the bot without an event loop to avoid crashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4456b6f348323a15b6f133b3cae9e