### PR TITLE
Log dropped messages for easier debugging

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -811,6 +811,65 @@ class SignalBot:
         return False
 
 
+    async def _handle_new_message(self, event):
+        """Process a new incoming message event."""
+        try:
+            text = event.message.message or ""
+            text = normalize_numbers(text)
+            snippet = text[:160].replace("\n", " ")
+            log.info(f"MSG from {event.chat_id}: {snippet} ...")
+
+            if not self._fresh_enough(getattr(event.message, "date", self.startup_time)):
+                return
+
+            if self._dedup_and_remember(int(event.chat_id), event.message):
+                return
+
+            profile = resolve_profile(int(event.chat_id))
+            formatted = parse_signal(text, event.chat_id, profile)
+            if not formatted:
+                log.info(f"Rejecting message from {event.chat_id}: {snippet}")
+                return
+
+            dests, template = self.resolve_targets(event.chat_id)
+            if template:
+                try:
+                    formatted = render_template(template, {"message": formatted})
+                except Exception as tmpl_err:
+                    log.error(f"Template render failed for {template}: {tmpl_err}")
+
+            for dest in dests:
+                try:
+                    await self.client.send_message(dest, formatted)
+                    log.info(f"SENT to {dest}")
+                except (ChatWriteForbiddenError, ChatAdminRequiredError) as e:
+                    log.error(f"Send failed to {dest} (permissions): {e}")
+                except Exception as e:
+                    log.warning(f"Send failed to {dest} (will attempt copy): {e}")
+                    try:
+                        if event.message.media:
+                            await self.client.send_file(
+                                dest,
+                                event.message.media,
+                                caption=formatted,
+                                force_document=False,
+                                allow_cache=False,
+                            )
+                        else:
+                            await self.client.send_message(dest, formatted)
+                        log.info(f"COPIED to {dest}")
+                    except Exception as copy_err:
+                        log.error(f"Copy failed to {dest}: {copy_err}")
+
+            if self._callback:
+                try:
+                    self._callback({"source_chat_id": str(event.chat_id), "text": formatted})
+                except Exception:
+                    pass
+        except Exception as e:
+            log.error(f"Handler error: {e}")
+
+
     # Start (with auto-reconnect loop)
     async def _run(self):
         if self._running:
@@ -829,61 +888,7 @@ class SignalBot:
 
             @self.client.on(events.NewMessage(chats=self.from_channels, incoming=True))
             async def handler(event):
-                """Receive, parse, and forward/copy."""
-                try:
-                    text = event.message.message or ""
-                    text = normalize_numbers(text)
-                    snippet = text[:160].replace("\n", " ")
-                    log.info(f"MSG from {event.chat_id}: {snippet} ...")
-
-                    if not self._fresh_enough(getattr(event.message, "date", self.startup_time)):
-                        return
-
-                    if self._dedup_and_remember(int(event.chat_id), event.message):
-                        return
-
-                    profile = resolve_profile(int(event.chat_id))
-                    formatted = parse_signal(text, event.chat_id, profile)
-                    if not formatted:
-                        return
-
-                    dests, template = self.resolve_targets(event.chat_id)
-                    if template:
-                        try:
-                            formatted = render_template(template, {"message": formatted})
-                        except Exception as tmpl_err:
-                            log.error(f"Template render failed for {template}: {tmpl_err}")
-
-                    for dest in dests:
-                        try:
-                            await self.client.send_message(dest, formatted)
-                            log.info(f"SENT to {dest}")
-                        except (ChatWriteForbiddenError, ChatAdminRequiredError) as e:
-                            log.error(f"Send failed to {dest} (permissions): {e}")
-                        except Exception as e:
-                            log.warning(f"Send failed to {dest} (will attempt copy): {e}")
-                            try:
-                                if event.message.media:
-                                    await self.client.send_file(
-                                        dest,
-                                        event.message.media,
-                                        caption=formatted,
-                                        force_document=False,
-                                        allow_cache=False,
-                                    )
-                                else:
-                                    await self.client.send_message(dest, formatted)
-                                log.info(f"COPIED to {dest}")
-                            except Exception as copy_err:
-                                log.error(f"Copy failed to {dest}: {copy_err}")
-
-                    if self._callback:
-                        try:
-                            self._callback({"source_chat_id": str(event.chat_id), "text": formatted})
-                        except Exception:
-                            pass
-                except Exception as e:
-                    log.error(f"Handler error: {e}")
+                await self._handle_new_message(event)
 
             try:
                 await self.client.start()

--- a/tests/test_logging_behavior.py
+++ b/tests/test_logging_behavior.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
+import asyncio
+
 from signal_bot import SignalBot
 
 
@@ -27,3 +29,26 @@ def test_dedup_logs_duplicate(caplog):
         assert bot._dedup_and_remember(123, msg) is False
         assert bot._dedup_and_remember(123, msg) is True
     assert any("Discarding duplicate" in r.message for r in caplog.records)
+
+
+class DummyEvent:
+    def __init__(self, chat_id, text):
+        self.chat_id = chat_id
+        self.message = DummyMsg(1, text)
+        # ensure message has date attribute
+        self.message.date = datetime.now(timezone.utc)
+
+
+def test_logs_rejected_message(caplog):
+    bot = SignalBot(1, 'hash', 'sess', [], [])
+    event = DummyEvent(123, "hello world")
+    loop = asyncio.new_event_loop()
+    try:
+        with caplog.at_level("INFO"):
+            loop.run_until_complete(bot._handle_new_message(event))
+    finally:
+        loop.close()
+    assert any(
+        "Rejecting message from 123" in r.message and "hello world" in r.message
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log incoming chat IDs and message snippets when parsing yields no signal
- refactor message handler into a reusable function
- add test to confirm rejection logs are emitted

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4456c0e408323b62cbc9cf86bce9b