### PR TITLE
Handle outgoing message events

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -887,7 +887,7 @@ class SignalBot:
             log.info("Connecting...")
             self.client = TelegramClient(StringSession(self.session_string), self.api_id, self.api_hash)
 
-            @self.client.on(events.NewMessage(chats=self.from_channels, incoming=True))
+            @self.client.on(events.NewMessage(chats=self.from_channels))
             async def handler(event):
                 await self._handle_new_message(event)
 


### PR DESCRIPTION
## Summary
- Process outgoing messages by removing `incoming=True` from the new-message handler.

## Testing
- `pytest -q`
- `API_ID=12345 API_HASH=abc SESSION_STRING=xyz python signal_bot.py` *(fails: ValueError: Not a valid string)*

------
https://chatgpt.com/codex/tasks/task_e_68b448310fec8323b91ae008b11064fe