### PR TITLE
Handle separate decimal and thousands separators in number normalization

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -128,15 +128,19 @@ def normalize_numbers(text: str) -> str:
         return ""
 
     # Map Eastern Arabic and Persian digits to Western Arabic numerals
-    trans = {ord(c): str(i) for i, c in enumerate("٠١٢٣٤٥٦٧٨٩")}
-    trans.update({ord(c): str(i) for i, c in enumerate("۰۱۲۳۴۵۶۷۸۹")})
+    digit_map = {ord(c): str(i) for i, c in enumerate("٠١٢٣٤٥٦٧٨٩")}
+    digit_map.update({ord(c): str(i) for i, c in enumerate("۰۱۲۳۴۵۶۷۸۹")})
 
-    # Normalize decimal and thousands separators
-    trans[ord("٫")] = "."  # Arabic decimal separator
-    trans[ord("٬")] = ""  # Arabic thousands separator (remove)
-    trans[ord(",")] = ""  # Comma thousands separator (remove)
+    # Separate mappings for thousands and decimal separators
+    thousands_map = {ord("٬"): None, ord(","): None}
+    decimal_map = {ord("٫"): "."}
 
-    return text.translate(trans)
+    # Apply mappings: strip thousands separators before decimals
+    text = text.translate(digit_map)
+    text = text.translate(thousands_map)
+    text = text.translate(decimal_map)
+
+    return text
 
 
 def guess_symbol(text: str) -> Optional[str]:

--- a/tests/test_normalize_numbers.py
+++ b/tests/test_normalize_numbers.py
@@ -4,3 +4,11 @@ from signal_bot import normalize_numbers
 def test_normalize_numbers_removes_commas():
     assert normalize_numbers("۱۲۳,۴۵۶") == "123456"
     assert normalize_numbers("1,234") == "1234"
+
+
+def test_normalize_numbers_farsi_with_separators():
+    assert normalize_numbers("۱٬۲۳۴٬۵۶۷٫۸۹") == "1234567.89"
+
+
+def test_normalize_numbers_arabic_with_separators():
+    assert normalize_numbers("١٬٢٣٤٬٥٦٧٫٨٩") == "1234567.89"


### PR DESCRIPTION
## Summary
- Improve `normalize_numbers` to strip thousands separators before replacing decimal separator
- Test Farsi and Arabic numerals containing both separators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44d21e0388323bdea294d528cd09e