### PR TITLE
Improve classic entry extraction fallback

### DIFF
--- a/tests/test_classic_extract_entry.py
+++ b/tests/test_classic_extract_entry.py
@@ -1,0 +1,11 @@
+import pytest
+from signal_bot import classic_extract_entry
+
+
+@pytest.mark.parametrize("lines, expected", [
+    (["Buy 1.2345 TP 1.2400 SL 1.2320"], "1.2345"),
+    (["TP 1.2400 SL 1.2320 Buy 1.2345"], "1.2345"),
+    (["Entry Price 1.2345, TP1 1.2400, SL 1.2320"], "1.2345"),
+])
+def test_classic_extract_entry_mixed_numbers(lines, expected):
+    assert classic_extract_entry(lines) == expected


### PR DESCRIPTION
## Summary
- refine `classic_extract_entry` to prefer numbers near `Buy`/`Sell` or entry/price keywords
- ignore numbers following TP/SL tokens
- add regression tests for mixed-number lines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44d22e49c83239b43c28aff28a5d1