### PR TITLE
Expand noise keyword detection

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -73,10 +73,37 @@ POS_VARIANTS = [
 
 # کلیدواژه‌های نویز/آپدیت/تبلیغ که باید نادیده بگیریم
 NON_SIGNAL_HINTS = [
-    "activated", "tp reached", "result so far", "screenshots", "cheers", "high-risk setup",
-    "move sl", "put your sl", "risk free", "close", "closed", "delete", "running",
-    "trade - update", "update", "guide", "watchlist", "broker", "subscription", "contact", "admin",
-    "tp almost", "tp hit", "tp reached", "sl reached", "sl hit", "profits", "week", "friday",
+    "activated",
+    "tp reached",
+    "result so far",
+    "screenshots",
+    "cheers",
+    "high-risk setup",
+    "move sl",
+    "put your sl",
+    "risk free",
+    "close",
+    "closed",
+    "partial close",
+    "delete",
+    "running",
+    "trade - update",
+    "update",
+    "analysis",
+    "setup",
+    "guide",
+    "watchlist",
+    "broker",
+    "subscription",
+    "contact",
+    "admin",
+    "tp almost",
+    "tp hit",
+    "sl reached",
+    "sl hit",
+    "profits",
+    "week",
+    "friday",
 ]
 
 TP_KEYS = ["tp", "take profit", "take-profit", "t/p", "t p"]
@@ -260,6 +287,11 @@ def calculate_rr(entry: str, sl: str, tp: str) -> Optional[str]:
 def looks_like_update(text: str) -> bool:
     t = (text or "").lower()
     return any(key in t for key in NON_SIGNAL_HINTS)
+
+
+def looks_like_noise_or_update(text: str) -> bool:
+    """Backward compatible wrapper for ``looks_like_update``."""
+    return looks_like_update(text)
 
 
 def is_valid(signal: Dict) -> bool:

--- a/tests/test_noise_keywords.py
+++ b/tests/test_noise_keywords.py
@@ -1,0 +1,13 @@
+import pytest
+from signal_bot import looks_like_noise_or_update
+
+
+@pytest.mark.parametrize("message", [
+    "Trade Update coming soon",
+    "Daily ANALYSIS released",
+    "New SETUP forming now",
+    "Consider a Partial Close at 50%",
+    "TP Reached on EURUSD"
+])
+def test_noise_keywords(message):
+    assert looks_like_noise_or_update(message)


### PR DESCRIPTION
## Summary
- broaden NON_SIGNAL_HINTS to cover update, analysis, setup, partial close, and tp reached terms
- expose `looks_like_noise_or_update` helper alias
- test case-insensitive detection of noise/update keywords

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b44d2568408323a0453fd1297a17bd