### PR TITLE
Require authentication for bot shutdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -364,6 +364,7 @@ def start_bot():
 
 
 @app.route("/stop_bot", methods=["POST"])
+@login_required
 def stop_bot():
     global bot_instance
     if not bot_instance or not bot_instance.is_running():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,3 +19,16 @@ def test_login_required(monkeypatch):
         client.post("/login", data={"username": "u", "password": "p"})
         resp = client.get("/")
         assert resp.status_code == 200
+
+
+def test_stop_bot_requires_login(monkeypatch):
+    app = _load_app(monkeypatch)
+    with app.app.test_client() as client:
+        resp = client.post("/stop_bot")
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
+        client.post("/login", data={"username": "u", "password": "p"})
+        resp = client.post("/stop_bot")
+        # successful stop redirects back to index
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/")


### PR DESCRIPTION
## Summary
- protect `/stop_bot` endpoint with `@login_required`
- test that unauthenticated users are redirected away from `/stop_bot`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b453c930f08323aae4b0c72e445090