### PR TITLE
Handle optional profile in parse_signal and fix profile test endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -298,7 +298,7 @@ def api_profile_test(name: str):
         except Exception:
             chat_id = 0
 
-    result = parse_signal(message, chat_id)
+    result = parse_signal(message, chat_id, profile.get("parse_options"))
     return jsonify({"parsed": result})
 
 

--- a/signal_bot.py
+++ b/signal_bot.py
@@ -631,7 +631,9 @@ def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
 
     return to_unified(signal, chat_id, signal.get("extra", {}))
 
-def parse_signal(text: str, chat_id: int, profile: Dict[str, Any]) -> Optional[str]:
+def parse_signal(
+    text: str, chat_id: int, profile: Dict[str, Any] | None = None
+) -> Optional[str]:
     profile = profile or {}
     text = normalize_numbers(text)
     # Special-case: United Kings parser

--- a/tests/test_api_profile_test.py
+++ b/tests/test_api_profile_test.py
@@ -1,0 +1,17 @@
+import os
+
+os.environ.setdefault("SESSION_SECRET", "test")
+
+from app import app, profiles_store
+
+
+def test_api_profile_test_handles_missing_profile_options():
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    profiles_store["dummy"] = {"parse_options": {}}
+    client = app.test_client()
+    resp = client.post("/api/profiles/dummy/test", json={"message": "test"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "parsed" in data
+    profiles_store.clear()


### PR DESCRIPTION
## Summary
- Allow `parse_signal` to accept an optional profile dictionary
- Pass profile parse options to `/api/profiles/<name>/test` endpoint
- Add regression test for `api_profile_test`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b453caa948832396f830255aaef555