### PR TITLE
chore: remove unused norm helper

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -157,10 +157,6 @@ def resolve_profile(chat_id: int) -> Dict[str, Any]:
     return CHANNEL_PROFILES.get(int(chat_id), {})
 
 
-def _norm(s: str) -> str:
-    return re.sub(r"\s+", " ", s).strip()
-
-
 def normalize_numbers(text: str) -> str:
     """Translate Persian/Arabic digits and separators to ASCII equivalents."""
     if not text:


### PR DESCRIPTION
## Summary
- remove unused `_norm` helper from `signal_bot`

## Testing
- `python -m py_compile signal_bot.py tests/test_norm_chat_identifier.py tests/test_normalize_numbers.py app.py profiles.py wsgi.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b453cd3f488323bba459283a70feee