### PR TITLE
Refine entry range detection using regex

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -144,8 +144,8 @@ UK_NOISE_LINES = [
     re.compile(r"result", re.IGNORECASE),
 ]
 
-# General entry range detector
-ENTRY_RANGE_RE = re.compile(r"(-?\d+(?:\.\d+)?)[^0-9]+(-?\d+(?:\.\d+)?)")
+# Entry range detector used to spot patterns like '@1234-1250'
+ENTRY_RANGE_RE = re.compile(r"@\s*\d+(?:\.\d+)?\s*[-–]\s*\d+(?:\.\d+)?")
 
 # Mapping of chat IDs to profile options controlling parsing behaviour.
 # Example: {1234: {"allow_entry_range": True, "show_entry_range_only": True}}
@@ -373,12 +373,9 @@ def is_valid(signal: Dict) -> bool:
     ]) and len(signal.get("tps", [])) >= 1
 
 
-def has_entry_range(lines: List[str]) -> bool:
-    """Detect whether any line contains an entry range."""
-    for l in lines:
-        if "entry" in l.lower() and ENTRY_RANGE_RE.search(l):
-            return True
-    return False
+def _has_entry_range(text: str) -> bool:
+    """Return True if ``text`` contains an entry range like ``@1234-1250``."""
+    return bool(ENTRY_RANGE_RE.search(text))
 
 
 def to_unified(signal: Dict, chat_id: int, extra: Optional[Dict] = None) -> str:
@@ -651,7 +648,7 @@ def parse_signal(
         log.info("IGNORED (empty)")
         return None
 
-    if has_entry_range(lines):
+    if _has_entry_range(text):
         if profile.get("allow_entry_range"):
             try:
                 res = parse_channel_four(text, chat_id)

--- a/tests/test_profile_entry_range.py
+++ b/tests/test_profile_entry_range.py
@@ -1,7 +1,14 @@
 import pytest
 from signal_bot import parse_signal, parse_channel_four
 
-MESSAGE = """#XAUUSD\nSell Limit\nEntry Range: 1930 - 1935\nTP1: 1920\nTP2: 1910\nSL: 1940\n"""
+MESSAGE = (
+    "#XAUUSD\nSell Limit\nEntry: @1930 - 1935\n"
+    "Take Profit 1: 1920\nTake Profit 2: 1910\nStop Loss: 1940\n"
+)
+
+SINGLE_PRICE_MESSAGE = (
+    "#XAUUSD\nSell\nEntry: @1930\nTake Profit 1: 1920\nStop Loss: 1940\n"
+)
 
 
 def test_parse_signal_respects_allow_entry_range_true():
@@ -13,4 +20,11 @@ def test_parse_signal_respects_allow_entry_range_true():
 def test_parse_signal_rejects_entry_range_when_not_allowed():
     profile = {}
     assert parse_signal(MESSAGE, 1234, profile) is None
+
+
+def test_parse_signal_accepts_single_price_with_at_prefix():
+    profile = {}
+    result = parse_signal(SINGLE_PRICE_MESSAGE, 1234, profile)
+    assert result is not None
+    assert "Entry Range" not in result
   

--- a/tests/test_show_entry_range_only.py
+++ b/tests/test_show_entry_range_only.py
@@ -2,7 +2,10 @@ import pytest
 from signal_bot import parse_signal, CHANNEL_PROFILES
 
 
-MESSAGE_WITH_RANGE = """#XAUUSD\nSell Limit\nEntry Range: 1930 - 1935\nTP1: 1920\nSL: 1940\n"""
+MESSAGE_WITH_RANGE = (
+    "#XAUUSD\nSell Limit\nEntry: @1930 - 1935\n"
+    "Take Profit 1: 1920\nStop Loss: 1940\n"
+)
 
 MESSAGE_NO_RANGE = """#BTCUSD\nBuy\nEntry: 100\nTP1: 110\nSL: 90\n"""
 


### PR DESCRIPTION
## Summary
- detect entry ranges with `@price1-price2` regex
- rely on new `_has_entry_range` for rejection logic
- add tests for single price vs range handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4555aef588323a87bb09bc1f715d4