### PR TITLE
Restrict symbol regex and add regression tests

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -51,8 +51,43 @@ from telethon.sessions import StringSession
 
 # نمادها/سیمبل‌ها
 PAIR_RE = re.compile(
-    r"(#?\b(?:XAUUSD|XAGUSD|GOLD|SILVER|USOIL|UKOIL|[A-Z]{3,5}[/ ]?[A-Z]{3,5}|[A-Z]{3,5}USD|USD[A-Z]{3,5})\b)"
+    r"(?:#)?(XAUUSD|XAGUSD|USOIL|[A-Z]{3}/[A-Z]{3}|[A-Z]{6})\b"
 )
+
+# Supported currency codes for validating symbol guesses
+CURRENCY_CODES = {
+    "USD",
+    "EUR",
+    "GBP",
+    "AUD",
+    "CAD",
+    "NZD",
+    "CHF",
+    "JPY",
+    "BTC",
+    "ETH",
+    "LTC",
+    "XAU",
+    "XAG",
+    "SGD",
+    "HKD",
+    "NOK",
+    "SEK",
+    "ZAR",
+    "TRY",
+    "RUB",
+    "CNY",
+    "CNH",
+    "MXN",
+    "BRL",
+    "INR",
+    "SAR",
+    "AED",
+    "PLN",
+}
+
+# Known non-FX instruments matched directly
+KNOWN_INSTRUMENTS = {"XAUUSD", "XAGUSD", "USOIL"}
 # عدد
 NUM_RE = re.compile(r"(-?\d+(?:\.\d+)?)")
 # R/R
@@ -183,9 +218,13 @@ def guess_symbol(text: str) -> Optional[str]:
     if not m:
         return None
     sym = m.group(1).upper().lstrip("#").replace(" ", "").replace("/", "")
-    if sym == "GOLD":
-        sym = "XAUUSD"
-    return sym
+    if sym in KNOWN_INSTRUMENTS:
+        return sym
+    if len(sym) == 6:
+        base, quote = sym[:3], sym[3:]
+        if base in CURRENCY_CODES and quote in CURRENCY_CODES:
+            return sym
+    return None
 
 
 def guess_position(text: str) -> Optional[str]:

--- a/tests/test_pair_regex.py
+++ b/tests/test_pair_regex.py
@@ -1,0 +1,8 @@
+import pytest
+
+from signal_bot import guess_symbol
+
+@pytest.mark.parametrize("text", ["UNITED", "ALRIGHT"])
+def test_invalid_words_not_matched(text):
+    assert guess_symbol(text) is None
+


### PR DESCRIPTION
## Summary
- Tighten PAIR_RE to cover only known instruments and valid FX pairs
- Validate matches against a whitelist of currency codes to avoid false positives
- Add regression tests to ensure common words like UNITED and ALRIGHT are not treated as symbols

## Testing
- `python -m pytest tests/test_pair_regex.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4555b96648323a569f1b42a47facc