### PR TITLE
Use low bound as entry for United Kings ranges

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -498,14 +498,13 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Optional[str]:
         return None
     p1, p2 = float(m.group(1)), float(m.group(2))
     lo, hi = (p1, p2) if p1 <= p2 else (p2, p1)
-    mid = (lo + hi) / 2
 
     def _fmt(x: float) -> str:
         s = f"{x:.5f}".rstrip("0").rstrip(".")
         return s
 
-    entry = _fmt(mid)
-    entry_range = (_fmt(lo), _fmt(hi))
+    entry = _fmt(lo)
+    entry_range = [_fmt(lo), _fmt(hi)]
 
     # SL
     sl = ""
@@ -549,14 +548,15 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Optional[str]:
         log.info(f"IGNORED (invalid) -> {signal}")
         return None
 
-    # sanity check: ensure TPs are in correct direction relative to midpoint
+    # sanity check: ensure TPs are in correct direction relative to entry
     try:
+        e = float(entry)
         for tp in tps:
             tv = float(tp)
-            if position.upper().startswith("SELL") and tv > mid:
+            if position.upper().startswith("SELL") and tv > e:
                 log.info(f"IGNORED (sell but TP {tp} > entry {entry})")
                 return None
-            if position.upper().startswith("BUY") and tv < mid:
+            if position.upper().startswith("BUY") and tv < e:
                 log.info(f"IGNORED (buy but TP {tp} < entry {entry})")
                 return None
     except Exception:


### PR DESCRIPTION
## Summary
- derive representative entry from the low value when United Kings signals provide a range and record the full range in metadata
- validate take-profits against this entry and update formatting accordingly
- test United Kings range parsing and new entry handling

## Testing
- `pytest tests/test_parse_united_kings.py::test_parse_united_kings_valid -q`
- `pytest tests/test_parse_united_kings.py::test_parse_united_kings_invalid -q`
- `pytest tests/test_parse_united_kings.py::test_parse_united_kings_noise -q`
- `pytest tests/test_parse_united_kings.py::test_united_kings_entry_range_assignment -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4555c9f0c83238b68e359262399ee