### PR TITLE
Improve United Kings symbol detection and entry range handling

### DIFF
--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -12,12 +12,12 @@ VALID_SIGNALS = [
     (
         """#XAUUSD\nBuy\n@1900-1910\nTP1 : 1915\nTP2 : 1920\nSL : 1890\n""",
         """\
-📊 #XAUUSD\n📉 Position: Buy\n❗️ R/R : 1/1.5\n💲 Entry Price : 1900\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1915\n✔️ TP2 : 1920\n🚫 Stop Loss : 1890""",
+📊 #XAUUSD\n📉 Position: Buy\n❗️ R/R : 1/1.5\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900.0 – 1910.0\n✔️ TP1 : 1915\n✔️ TP2 : 1920\n🚫 Stop Loss : 1890""",
     ),
     (
         """#XAUUSD\nSell\n@1900-1910\nTP1 : 1890\nTP2 : 1880\nSL : 1910\n""",
         """\
-📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1/1\n💲 Entry Price : 1900\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1910""",
+📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1/1\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900.0 – 1910.0\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1910""",
     ),
 ]
 
@@ -66,5 +66,5 @@ def test_united_kings_entry_range_assignment(monkeypatch):
     message = """#XAUUSD\nBuy\n@1900-1910\nTP1 : 1915\nSL : 1890\n"""
     parse_signal_united_kings(message, 1234)
 
-    assert captured["signal"]["entry"] == "1900"
-    assert captured["extra"]["entries"]["range"] == ["1900", "1910"]
+    assert captured["signal"]["entry"] == "1900.0"
+    assert captured["extra"]["entries"]["range"] == [1900.0, 1910.0]

--- a/tests/test_united_kings.py
+++ b/tests/test_united_kings.py
@@ -2,8 +2,9 @@ from signal_bot import parse_signal, _looks_like_united_kings, UNITED_KINGS_CHAT
 
 NEW_CHAT_ID = -1001234567890
 
-MESSAGE = """Buy
-1900-1910
+MESSAGE = """GOLD
+Buy
+@1900-1910
 TP1 : 1915
 TP2 : 1920
 SL : 1890
@@ -12,9 +13,9 @@ SL : 1890
 EXPECTED = """\
 📊 #XAUUSD
 📉 Position: Buy
-❗️ R/R : 1.5/1
-💲 Entry Price : 1905
-🎯 Entry Range : 1900 – 1910
+❗️ R/R : 1/1.5
+💲 Entry Price : 1900.0
+🎯 Entry Range : 1900.0 – 1910.0
 ✔️ TP1 : 1915
 ✔️ TP2 : 1920
 🚫 Stop Loss : 1890"""


### PR DESCRIPTION
## Summary
- Detect instrument symbol in United Kings messages by scanning each line for GOLD or other symbol guesses
- Capture entry range with explicit `@` pattern, saving the minimum entry value and numeric range
- Adjust tests for new parsing behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45c0bf5f0832385da9e7142bbf3d5