### PR TITLE
Expand entry range dash support

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -186,7 +186,12 @@ UK_ACTION_RE = re.compile(
 )
 
 # Entry range detector used to spot patterns like '@1234-1250'
-ENTRY_RANGE_RE = re.compile(r"@\s*\d+(?:\.\d+)?\s*[-–]\s*\d+(?:\.\d+)?")
+# Entry ranges may use various dash-like characters between the numbers.
+# Accept common forms such as hyphen-minus (-), en dash (–), em dash (—)
+# and the unicode minus sign (−).
+ENTRY_RANGE_RE = re.compile(
+    r"@\s*\d+(?:\.\d+)?\s*[-–—−]\s*\d+(?:\.\d+)?"
+)
 
 # Mapping of chat IDs to profile options controlling parsing behaviour.
 # Example: {1234: {"allow_entry_range": True, "show_entry_range_only": True}}

--- a/tests/test_has_entry_range.py
+++ b/tests/test_has_entry_range.py
@@ -1,0 +1,8 @@
+import pytest
+from signal_bot import _has_entry_range
+
+
+@pytest.mark.parametrize("dash", ["-", "–", "—", "−"])
+def test_has_entry_range_accepts_various_dashes(dash):
+    text = f"@123{dash}124"
+    assert _has_entry_range(text)


### PR DESCRIPTION
## Summary
- Allow em dashes and unicode minus signs in entry range regex
- Test `_has_entry_range` against multiple dash characters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45f9eab2483238d6043d121b7bff2