### PR TITLE
Use lower bound as United Kings entry

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -587,7 +587,7 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Optional[str]:
 
     range_str = m.group(0)
     if "@" in range_str:
-        entry = _fmt(lo)
+        entry = f"{lo}"
     else:
         mid = (lo + hi) / 2
         entry = _fmt(mid)

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -12,12 +12,12 @@ VALID_SIGNALS = [
     (
         """#XAUUSD\nBuy gold\n@1900-1910\nTP1 : 1915\nTP2 : 1920\nSL : 1890\n""",
         """\
-📊 #XAUUSD\n📉 Position: Buy\n❗️ R/R : 1/1.5\n💲 Entry Price : 1900\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1915\n✔️ TP2 : 1920\n🚫 Stop Loss : 1890""",
+📊 #XAUUSD\n📉 Position: Buy\n❗️ R/R : 1/1.5\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1915\n✔️ TP2 : 1920\n🚫 Stop Loss : 1890""",
     ),
     (
         """#XAUUSD\nSell gold\n@1900-1910\nTP1 : 1890\nTP2 : 1880\nSL : 1910\n""",
         """\
-📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1/1\n💲 Entry Price : 1900\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1910""",
+📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1/1\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1910""",
     ),
 ]
 
@@ -66,5 +66,5 @@ def test_united_kings_entry_range_assignment(monkeypatch):
     message = """#XAUUSD\nBuy\n@1900-1910\nTP1 : 1915\nSL : 1890\n"""
     parse_signal_united_kings(message, 1234)
 
-    assert captured["signal"]["entry"] == "1900"
+    assert captured["signal"]["entry"] == "1900.0"
     assert captured["extra"]["entries"]["range"] == ["1900", "1910"]

--- a/tests/test_united_kings.py
+++ b/tests/test_united_kings.py
@@ -12,7 +12,7 @@ EXPECTED = """\
 📊 #XAUUSD
 📉 Position: Buy
 ❗️ R/R : 1/1.5
-💲 Entry Price : 1900
+💲 Entry Price : 1900.0
 🎯 Entry Range : 1900 – 1910
 ✔️ TP1 : 1915
 ✔️ TP2 : 1920


### PR DESCRIPTION
## Summary
- Parse United Kings entry ranges using the lower bound directly
- Adjust tests to expect the updated entry representation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b45fac8dcc83238df960e2769e8e25