### PR TITLE
feat: support silver signals in united kings parser

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -561,7 +561,19 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Optional[str]:
     if not lines:
         log.info("IGNORED (empty)")
         return None
-    symbol = "XAUUSD"
+
+    # Determine traded instrument based on keywords.
+    symbol = "XAUUSD"  # Default to gold
+    upper_lines = [l.upper().replace("#", "") for l in lines]
+    symbol_keywords = [
+        ("XAGUSD", ["SILVER", "XAGUSD", "XAG"]),
+        ("USOIL", ["USOIL", "OIL"]),
+        ("XAUUSD", ["GOLD", "XAUUSD", "XAU"]),
+    ]
+    for sym, words in symbol_keywords:
+        if any(any(w in line for w in words) for line in upper_lines):
+            symbol = sym
+            break
 
     position = ""
     if any(UK_BUY_RE.search(l) for l in lines):

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -68,3 +68,10 @@ def test_united_kings_entry_range_assignment(monkeypatch):
 
     assert captured["signal"]["entry"] == "1900"
     assert captured["extra"]["entries"]["range"] == ["1900", "1910"]
+
+
+def test_parse_united_kings_silver():
+    message = """Buy silver\n@24-24.5\nTP1 : 25\nTP2 : 25.5\nSL : 23.5\n"""
+    expected = """\
+📊 #XAGUSD\n📉 Position: Buy\n❗️ R/R : 1/2\n💲 Entry Price : 24\n🎯 Entry Range : 24 – 24.5\n✔️ TP1 : 25\n✔️ TP2 : 25.5\n🚫 Stop Loss : 23.5"""
+    assert parse_signal(message, -1002223574325, {}) == expected


### PR DESCRIPTION
## Summary
- detect "SILVER" and other keywords in United Kings messages and map them to the right ticker
- test parsing of United Kings silver signals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45fada92483238d29f6fd8284f8ce