### PR TITLE
Ensure empty signals return before United Kings parsing

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -719,11 +719,16 @@ def parse_signal(
 ) -> Optional[str]:
     profile = profile or {}
     text = normalize_numbers(text)
-    lines = _strip_noise_lines((text or "").splitlines())
+    if not text:
+        log.info("IGNORED (empty)")
+        return None
+
+    lines = _strip_noise_lines(text.splitlines())
     text = "\n".join(lines)
     if not text:
         log.info("IGNORED (empty)")
         return None
+
     # Special-case: United Kings parser
     if chat_id in UNITED_KINGS_CHAT_IDS or _looks_like_united_kings(text):
         try:
@@ -736,10 +741,6 @@ def parse_signal(
     # حذف پیام‌های غیرسیگنال (آپدیت/تبلیغ/نتیجه)
     if looks_like_update(text):
         log.info("IGNORED (update/noise)")
-        return None
-
-    if not lines:
-        log.info("IGNORED (empty)")
         return None
 
     if _has_entry_range(text):


### PR DESCRIPTION
## Summary
- Return early when `parse_signal` receives empty input
- Avoid calling the United Kings parser on empty messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b45fb585048323a2c1df01dffc724f