### PR TITLE
Use persistent profile store

### DIFF
--- a/tests/test_api_profile_test.py
+++ b/tests/test_api_profile_test.py
@@ -1,17 +1,25 @@
 import os
+import importlib
 
 os.environ.setdefault("SESSION_SECRET", "test")
 
-from app import app, profiles_store
+from profiles import ProfileStore
 
 
-def test_api_profile_test_handles_missing_profile_options():
+def test_api_profile_test_handles_missing_profile_options(tmp_path):
+    app_module = importlib.reload(importlib.import_module("app"))
+    app_module.profiles_store = ProfileStore(tmp_path / "profiles.json")
+    app_module._load_profiles_into_channel_profiles()
+    app = app_module.app
     app.config["TESTING"] = True
     app.config["WTF_CSRF_ENABLED"] = False
-    profiles_store["dummy"] = {"parse_options": {}}
     client = app.test_client()
+    resp_create = client.post(
+        "/api/profiles",
+        json={"name": "dummy", "parse_options": {}},
+    )
+    assert resp_create.status_code == 201
     resp = client.post("/api/profiles/dummy/test", json={"message": "test"})
     assert resp.status_code == 200
     data = resp.get_json()
     assert "parsed" in data
-    profiles_store.clear()

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,11 +1,19 @@
 import importlib
+import tempfile
+
 import pytest
+
+from profiles import ProfileStore
 
 
 def _load_app(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
-    app = importlib.reload(importlib.import_module("app"))
-    return app
+    app_module = importlib.reload(importlib.import_module("app"))
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    app_module.profiles_store = ProfileStore(tmp.name)
+    app_module._load_profiles_into_channel_profiles()
+    return app_module
 
 
 @pytest.mark.parametrize(

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,10 +1,8 @@
-from pathlib import Path
-
 from profiles import ChannelProfile, ProfileStore
 
 
 def test_profile_crud(tmp_path):
-    store = ProfileStore(tmp_path / "profiles.yaml")
+    store = ProfileStore(tmp_path / "profiles.json")
     profile = ChannelProfile(
         id="p1",
         name="Profile 1",


### PR DESCRIPTION
## Summary
- persist channel profiles using ProfileStore and load parse options on startup
- route all profile CRUD APIs through ProfileStore and refresh channel parsing options
- update tests to use temporary JSON-backed stores

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4627c5a648323869fc0422e27afca