### PR TITLE
Validate TP/SL against entry and ranges

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -557,6 +557,62 @@ def _looks_like_united_kings(text: str) -> bool:
     return True
 
 
+def _validate_tp_sl(
+    position: str,
+    entry: str,
+    sl: str,
+    tps: List[str],
+    entry_range: Optional[Tuple[str, str]] = None,
+) -> bool:
+    """Return True if TP/SL values are consistent with *entry*.
+
+    For ``BUY`` positions the stop loss must be below the entry price and at
+    least one take-profit target must be above it.  ``SELL`` signals require the
+    opposite.  When an ``entry_range`` is supplied, the lower bound is used for
+    stop-loss validation and the upper bound for take-profit checks.  A warning
+    is emitted if any TP or SL falls *within* the provided range, as this often
+    indicates an inconsistent signal.
+    """
+
+    try:
+        e = float(entry)
+        sl_v = float(sl)
+        tp_vals = [float(tp) for tp in tps]
+        lo, hi = e, e
+        if entry_range:
+            lo, hi = sorted(float(x) for x in entry_range)
+
+        pos = position.upper()
+        if pos.startswith("BUY"):
+            if sl_v >= lo:
+                log.info(f"IGNORED (buy but SL {sl} >= entry {entry})")
+                return False
+            if any(tv < lo for tv in tp_vals):
+                log.info(f"IGNORED (buy but TP {tp_vals[0]} < entry {entry})")
+                return False
+            if all(tv < (hi if entry_range else e) for tv in tp_vals):
+                log.info(f"IGNORED (buy but all TP < entry {entry})")
+                return False
+            if entry_range and (any(lo <= tv <= hi for tv in tp_vals) or lo <= sl_v <= hi):
+                log.warning("TP/SL inside entry range")
+        elif pos.startswith("SELL"):
+            boundary = lo if entry_range else e
+            if sl_v <= boundary:
+                log.info(f"IGNORED (sell but SL {sl} <= entry {entry})")
+                return False
+            if any(tv > boundary for tv in tp_vals):
+                log.info(f"IGNORED (sell but TP {tp_vals[0]} > entry {entry})")
+                return False
+            if all(tv > boundary for tv in tp_vals):
+                log.info(f"IGNORED (sell but all TP > entry {entry})")
+                return False
+            if entry_range and (any(lo <= tv <= hi for tv in tp_vals) or lo <= sl_v <= hi):
+                log.warning("TP/SL inside entry range")
+    except Exception:
+        pass
+    return True
+
+
 def parse_signal_united_kings(text: str, chat_id: int) -> Optional[str]:
     """Parse a United Kings style signal.
 
@@ -665,20 +721,8 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Optional[str]:
     if not is_valid(signal):
         log.info(f"IGNORED (invalid) -> {signal}")
         return None
-
-    # sanity check: ensure TPs are in correct direction relative to entry
-    try:
-        e = float(entry)
-        for tp in tps:
-            tv = float(tp)
-            if position.upper().startswith("SELL") and tv > e:
-                log.info(f"IGNORED (sell but TP {tp} > entry {entry})")
-                return None
-            if position.upper().startswith("BUY") and tv < e:
-                log.info(f"IGNORED (buy but TP {tp} < entry {entry})")
-                return None
-    except Exception:
-        pass
+    if not _validate_tp_sl(position, entry, sl, tps, tuple(entry_range)):
+        return None
 
     return to_unified(signal, chat_id, extra)
 
@@ -729,19 +773,8 @@ def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
     if not is_valid(signal):
         log.info(f"IGNORED (invalid) -> {signal}")
         return None
-
-    try:
-        e = float(entry)
-        for tp in tps:
-            tv = float(tp)
-            if position.upper().startswith("SELL") and tv > e:
-                log.info(f"IGNORED (sell but TP {tp} > entry {entry})")
-                return None
-            if position.upper().startswith("BUY") and tv < e:
-                log.info(f"IGNORED (buy but TP {tp} < entry {entry})")
-                return None
-    except Exception:
-        pass
+    if not _validate_tp_sl(position, entry, sl, tps, entry_range):
+        return None
 
     return to_unified(signal, chat_id, signal.get("extra", {}))
 
@@ -778,11 +811,10 @@ def parse_signal(
     if _has_entry_range(text):
         if profile.get("allow_entry_range"):
             try:
-                res = parse_channel_four(text, chat_id)
-                if res is not None:
-                    return res
+                return parse_channel_four(text, chat_id)
             except Exception as e:
                 log.debug(f"Entry range parser failed: {e}")
+                return None
         else:
             log.info("IGNORED (entry range not allowed)")
             return None
@@ -809,19 +841,8 @@ def parse_signal(
         log.info(f"IGNORED (invalid) -> {signal}")
         return None
 
-    # sanity check: جهت TPها با Entry همخوان باشد
-    try:
-        e = float(entry)
-        for tp in tps:
-            tv = float(tp)
-            if position.upper().startswith("SELL") and tv > e:
-                log.info(f"IGNORED (sell but TP {tp} > entry {entry})")
-                return None
-            if position.upper().startswith("BUY") and tv < e:
-                log.info(f"IGNORED (buy but TP {tp} < entry {entry})")
-                return None
-    except Exception:
-        pass
+    if not _validate_tp_sl(position, entry, sl, tps):
+        return None
 
     return to_unified(signal, chat_id, signal.get("extra", {}))
 

--- a/tests/test_parse_channel_four.py
+++ b/tests/test_parse_channel_four.py
@@ -25,6 +25,12 @@ INVALID_SIGNALS = [
     """#XAUUSD\nSell Limit\nEntry Range: 1930 - 1935\nTP1: 1920\nTP2: 1940\nSL: 1945\n""",
     # Mixed TP directions (buy with TP below entry)
     """#EURUSD\nBuy\nEntry Range: 1.0800-1.0810\nTP1: 1.0850\nTP2: 1.0700\nSL: 1.0750\n""",
+    # SL not below entry for buy
+    """#XAUUSD\nBuy\nEntry Range: 1900-1910\nTP1: 1915\nTP2: 1920\nSL: 1905\n""",
+    # SL not above entry for sell
+    """#XAUUSD\nSell\nEntry Range: 1900-1910\nTP1: 1895\nTP2: 1890\nSL: 1895\n""",
+    # TP values inside entry range for buy
+    """#XAUUSD\nBuy\nEntry Range: 1900-1910\nTP1: 1905\nTP2: 1908\nSL: 1890\n""",
 ]
 
 # Noise messages that should be ignored

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -34,6 +34,16 @@ INVALID_SIGNALS = [
     """#XAUUSD\nSell\n@1900-1910\nTP1 : 1912\nTP2 : 1890\nSL : 1915\n""",
     # Missing position
     """#XAUUSD\n@1900-1910\nTP1 : 1915\nSL : 1890\n""",
+    # SL not below entry for buy
+    """#XAUUSD\nBuy\nEntry Price : 1900\nTP1 : 1910\nTP2 : 1920\nStop Loss : 1905\n""",
+    # SL not above entry for sell
+    """#XAUUSD\nSell\nEntry Price : 1900\nTP1 : 1890\nTP2 : 1880\nStop Loss : 1895\n""",
+    # Range with TP inside entry range for buy
+    """#XAUUSD\nBuy\n@1900-1910\nTP1 : 1905\nTP2 : 1908\nSL : 1890\n""",
+    # Range with SL inside range for buy
+    """#XAUUSD\nBuy\n@1900-1910\nTP1 : 1915\nSL : 1905\n""",
+    # Range with SL inside range for sell
+    """#XAUUSD\nSell\n@1900-1910\nTP1 : 1890\nSL : 1905\n""",
 ]
 
 NOISE_MESSAGES = [

--- a/tests/test_tp_sl_validation.py
+++ b/tests/test_tp_sl_validation.py
@@ -1,0 +1,46 @@
+import pytest
+from signal_bot import parse_signal
+
+
+def test_parse_signal_rejects_buy_sl_not_below_entry():
+    message = (
+        "#XAUUSD\nBuy\nEntry Price : 1900\nTP1 : 1905\nTP2 : 1910\nStop Loss : 1901\n"
+    )
+    assert parse_signal(message, 1234, {}) is None
+
+
+def test_parse_signal_rejects_sell_sl_not_above_entry():
+    message = (
+        "#XAUUSD\nSell\nEntry Price : 1900\nTP1 : 1895\nTP2 : 1890\nStop Loss : 1899\n"
+    )
+    assert parse_signal(message, 1234, {}) is None
+
+
+def test_parse_signal_rejects_buy_all_tp_below_entry():
+    message = (
+        "#XAUUSD\nBuy\nEntry Price : 1900\nTP1 : 1890\nTP2 : 1895\nStop Loss : 1880\n"
+    )
+    assert parse_signal(message, 1234, {}) is None
+
+
+def test_parse_signal_rejects_sell_all_tp_above_entry():
+    message = (
+        "#XAUUSD\nSell\nEntry Price : 1900\nTP1 : 1910\nTP2 : 1920\nStop Loss : 1925\n"
+    )
+    assert parse_signal(message, 1234, {}) is None
+
+
+def test_parse_signal_entry_range_invalid_tp():
+    profile = {"allow_entry_range": True}
+    message = (
+        "#XAUUSD\nBuy\nEntry: @1900-1910\nTP1: 1905\nTP2: 1908\nSL: 1890\n"
+    )
+    assert parse_signal(message, 1234, profile) is None
+
+
+def test_parse_signal_entry_range_invalid_sl():
+    profile = {"allow_entry_range": True}
+    message = (
+        "#XAUUSD\nSell\nEntry: @1930-1935\nTP1: 1920\nTP2: 1910\nSL: 1925\n"
+    )
+    assert parse_signal(message, 1234, profile) is None


### PR DESCRIPTION
## Summary
- add `_validate_tp_sl` helper to check TP/SL direction and warn on range conflicts
- enforce TP/SL validation in `parse_signal`, `parse_signal_united_kings`, and `parse_channel_four`
- reject entry-range signals when parsing fails and test invalid TP/SL scenarios

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b462af36bc8323809ca6894ffc24fc