### PR TITLE
Add dashboard route with message statistics

### DIFF
--- a/app.py
+++ b/app.py
@@ -429,6 +429,17 @@ def status():
     running = bool(bot_instance and bot_instance.is_running())
     return jsonify({"running": running})
 
+
+@app.route("/dashboard")
+@login_required
+def dashboard():
+    stats = (
+        bot_instance.stats.snapshot()
+        if bot_instance
+        else {"received": 0, "filtered": 0, "parsed": 0, "sent": 0, "rejected": 0, "messages": []}
+    )
+    return render_template("dashboard.html", stats=stats)
+
 @app.route("/health")
 def health():
     return "OK", 200

--- a/signal_bot.py
+++ b/signal_bot.py
@@ -32,6 +32,7 @@ import hashlib
 import time
 from datetime import datetime, timezone, timedelta
 from collections import deque
+from threading import Lock
 from typing import List, Dict, Optional, Iterable, Callable, Union, Deque, Tuple, Any
 
 from jinja2 import Environment, FileSystemLoader, Template, select_autoescape
@@ -902,6 +903,43 @@ def _coerce_channel_id(x: Union[int, str]) -> Union[int, str]:
 
 
 # ----------------------------------------------------------------------------
+# Statistics helper
+# ----------------------------------------------------------------------------
+
+
+class BotStats:
+    """Thread-safe counters and recent message storage."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self.received = 0
+        self.filtered = 0
+        self.parsed = 0
+        self.sent = 0
+        self.rejected = 0
+        self.messages: Deque[dict] = deque(maxlen=20)
+
+    def increment(self, field: str, amount: int = 1) -> None:
+        with self._lock:
+            setattr(self, field, getattr(self, field) + amount)
+
+    def record(self, text: str, status: str, reason: str | None = None) -> None:
+        with self._lock:
+            self.messages.appendleft({"text": text, "status": status, "reason": reason})
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "received": self.received,
+                "filtered": self.filtered,
+                "parsed": self.parsed,
+                "sent": self.sent,
+                "rejected": self.rejected,
+                "messages": list(self.messages),
+            }
+
+
+# ----------------------------------------------------------------------------
 # SignalBot class (kept, with stability fixes: freshness + dedupe)
 # ----------------------------------------------------------------------------
 
@@ -964,6 +1002,7 @@ class SignalBot:
         self.retry_delay = retry_delay
         self.max_retries = max_retries
         self.loop: Optional[asyncio.AbstractEventLoop] = None
+        self.stats = BotStats()
         
         # freshness/dedupe state
         self.startup_time = datetime.now(timezone.utc)
@@ -1067,19 +1106,27 @@ class SignalBot:
             text = event.message.message or ""
             snippet = text[:160].replace("\n", " ")
             log.info(f"MSG from {event.chat_id}: {snippet} ...")
+            self.stats.increment("received")
 
             if not self._fresh_enough(getattr(event.message, "date", self.startup_time)):
+                self.stats.increment("filtered")
+                self.stats.record(snippet, "filtered", "stale")
                 return
 
             if self._dedup_and_remember(int(event.chat_id), event.message):
+                self.stats.increment("filtered")
+                self.stats.record(snippet, "filtered", "duplicate")
                 return
 
             profile = resolve_profile(int(event.chat_id))
             formatted = parse_signal(text, event.chat_id, profile)
             if not formatted:
                 log.info(f"Rejecting message from {event.chat_id}: {snippet}")
+                self.stats.increment("rejected")
+                self.stats.record(snippet, "rejected", "parse")
                 return
 
+            self.stats.increment("parsed")
             dests, template = self.resolve_targets(event.chat_id)
             if template:
                 try:
@@ -1087,10 +1134,12 @@ class SignalBot:
                 except Exception as tmpl_err:
                     log.error(f"Template render failed for {template}: {tmpl_err}")
 
+            sent_any = False
             for dest in dests:
                 try:
                     await self.client.send_message(dest, formatted)
                     log.info(f"SENT to {dest}")
+                    sent_any = True
                 except (ChatWriteForbiddenError, ChatAdminRequiredError) as e:
                     log.error(f"Send failed to {dest} (permissions): {e}")
                 except Exception as e:
@@ -1107,8 +1156,16 @@ class SignalBot:
                         else:
                             await self.client.send_message(dest, formatted)
                         log.info(f"COPIED to {dest}")
+                        sent_any = True
                     except Exception as copy_err:
                         log.error(f"Copy failed to {dest}: {copy_err}")
+
+            if sent_any:
+                self.stats.increment("sent")
+                self.stats.record(snippet, "sent")
+            else:
+                self.stats.increment("rejected")
+                self.stats.record(snippet, "rejected", "send")
 
             if self._callback:
                 try:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>داشبورد</h2>
+<div class="row" style="margin-bottom:12px;">
+  <span class="pill">Received: {{ stats.received }}</span>
+  <span class="pill">Filtered: {{ stats.filtered }}</span>
+  <span class="pill">Parsed: {{ stats.parsed }}</span>
+  <span class="pill">Sent: {{ stats.sent }}</span>
+  <span class="pill">Rejected: {{ stats.rejected }}</span>
+</div>
+<h3>آخرین پیام‌ها</h3>
+<ul>
+  {% for m in stats.messages %}
+  <li>{{ m.text }} - {{ m.status }}{% if m.reason %} ({{ m.reason }}){% endif %}</li>
+  {% else %}
+  <li>هیچ پیامی پردازش نشده.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,18 @@
+import importlib
+
+
+def _load_app(monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET", "test")
+    monkeypatch.setenv("ADMIN_USER", "u")
+    monkeypatch.setenv("ADMIN_PASS", "p")
+    app = importlib.reload(importlib.import_module("app"))
+    app.app.config["WTF_CSRF_ENABLED"] = False
+    return app
+
+
+def test_dashboard_route(monkeypatch):
+    app = _load_app(monkeypatch)
+    with app.app.test_client() as client:
+        client.post("/login", data={"username": "u", "password": "p"})
+        resp = client.get("/dashboard")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Track message processing stats in `SignalBot` with thread-safe counters and recent messages
- Add `/dashboard` Flask route and template displaying stats
- Cover dashboard route with tests

## Testing
- `pytest tests/test_dashboard.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b463d042648323a850ea38ce25b4ed