### PR TITLE
Handle Persian/English noise hints and normalization

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -121,7 +121,10 @@ POS_VARIANTS = [
 ]
 
 # کلیدواژه‌های نویز/آپدیت/تبلیغ که باید نادیده بگیریم
+# این فهرست به‌صورت دوزبانه (انگلیسی/فارسی) نگهداری می‌شود و همگی به حروف
+# کوچک و بدون نیم‌فاصله نرمال می‌شوند.
 NON_SIGNAL_HINTS = [
+    # English noise/update hints
     "activated",
     "tp reached",
     "result so far",
@@ -153,7 +156,39 @@ NON_SIGNAL_HINTS = [
     "profits",
     "week",
     "friday",
+    "make tp",
+    "make sl",
+    "make tp/sl",
+    "change tp",
+    "change sl",
+    "change tp/sl",
+    "upgrade your subscription",
+    # Persian noise/update hints
+    "آپدیت",
+    "فعال شد",
+    "اسکرین شات",
+    "اسکرینشات",
+    "تبریک",
 ]
+
+# الگوی حذف ایموجی‌ها قبل از بررسی کلیدواژه‌ها
+EMOJI_RE = re.compile(
+    "["
+    "\U0001F1E6-\U0001F1FF"  # flags
+    "\U0001F300-\U0001F5FF"  # symbols & pictographs
+    "\U0001F600-\U0001F64F"  # emoticons
+    "\U0001F680-\U0001F6FF"  # transport & map symbols
+    "\U0001F700-\U0001F77F"  # alchemical symbols
+    "\U0001F780-\U0001F7FF"  # Geometric Shapes Extended
+    "\U0001F800-\U0001F8FF"  # Supplemental Arrows-C
+    "\U0001F900-\U0001F9FF"  # Supplemental Symbols and Pictographs
+    "\U0001FA00-\U0001FA6F"  # Chess Symbols etc.
+    "\U0001FA70-\U0001FAFF"  # Symbols and Pictographs Extended-A
+    "\u2600-\u26FF"          # Misc symbols
+    "\u2700-\u27BF"          # Dingbats
+    "]+",
+    flags=re.UNICODE,
+)
 
 # Lines that are purely visual dividers ("----", "====", etc.)
 DIVIDER_LINE_RE = re.compile(r"^[\s\-\–\—\_\=\·\.\•\*➖]+$")
@@ -419,8 +454,17 @@ def calculate_rr(entry: str, sl: str, tp: str) -> Optional[str]:
         return f"1/{fmt(reward / risk)}"
 
 
+def _normalize_hint_text(text: str) -> str:
+    """Return *text* with half-spaces and emojis normalised for matching."""
+    if not text:
+        return ""
+    text = text.replace("\u200c", " ")
+    text = EMOJI_RE.sub(" ", text)
+    return text
+
+
 def looks_like_update(text: str) -> bool:
-    t = (text or "").lower()
+    t = _normalize_hint_text(text).lower()
     return any(key in t for key in NON_SIGNAL_HINTS)
 
 

--- a/tests/test_noise_keywords.py
+++ b/tests/test_noise_keywords.py
@@ -7,7 +7,14 @@ from signal_bot import looks_like_noise_or_update
     "Daily ANALYSIS released",
     "New SETUP forming now",
     "Consider a Partial Close at 50%",
-    "TP Reached on EURUSD"
+    "TP Reached on EURUSD",
+    "Please make TP/SL now",
+    "Change TP/SL to 1.2345",
+    "Time to upgrade your subscription",
+    "آپدیت ✅",
+    "سیگنال فعال شد",
+    "لطفا اسکرین‌شات بفرست",
+    "تبریک 🎉",
 ])
 def test_noise_keywords(message):
     assert looks_like_noise_or_update(message)

--- a/tests/test_parsing_noise.py
+++ b/tests/test_parsing_noise.py
@@ -14,6 +14,10 @@ NOISY_CLEAN_PAIRS = [
         """------------------\nDaily ANALYSIS\n#XAUUSD\nSell\nEntry 1900\nSL 1910\nTP1 1890\n""",
         """#XAUUSD\nSell\nEntry 1900\nSL 1910\nTP1 1890\n""",
     ),
+    (
+        """آپدیت✅\n#USDJPY\nBuy\nEntry 110\nSL 109\nTP1 111\n""",
+        """#USDJPY\nBuy\nEntry 110\nSL 109\nTP1 111\n""",
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- Expand NON_SIGNAL_HINTS with Persian and new English phrases
- Normalize half-spaces and emojis before hint matching
- Test ignoring Persian and English noise phrases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46599ea248323b28437128a6e21e8