### PR TITLE
Handle additional United Kings noise lines

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -188,7 +188,10 @@ UK_TP_RE = re.compile(r"\bT\s*P\s*\d*\s*[:@-]?\s*(-?\d+(?:\.\d+)?)", re.IGNORECA
 UK_NOISE_LINES = [
     re.compile(r"united\s+kings", re.IGNORECASE),
     re.compile(r"tp\s+(?:hit|reached)", re.IGNORECASE),
+    re.compile(r"tp\s*almost", re.IGNORECASE),
     re.compile(r"sl\s+(?:hit|reached)", re.IGNORECASE),
+    re.compile(r"break\s*even", re.IGNORECASE),
+    re.compile(r"risk\s*free", re.IGNORECASE),
     re.compile(r"result", re.IGNORECASE),
 ]
 

--- a/tests/test_united_kings.py
+++ b/tests/test_united_kings.py
@@ -1,4 +1,11 @@
-from signal_bot import parse_signal, _looks_like_united_kings, UNITED_KINGS_CHAT_IDS
+import pytest
+
+from signal_bot import (
+    parse_signal,
+    _looks_like_united_kings,
+    _clean_uk_lines,
+    UNITED_KINGS_CHAT_IDS,
+)
 
 NEW_CHAT_ID = -1002223574325
 
@@ -38,3 +45,20 @@ def test_parse_united_kings_unknown_id_detection():
 
 def test_parse_united_kings_known_chat_id():
     assert parse_signal(MESSAGE, NEW_CHAT_ID, {}) == EXPECTED
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "TP almost hit",
+        "SL hit 1900",
+        "SL reached 1900",
+        "Breakeven now",
+        "Break even achieved",
+        "Trade is risk free",
+        "Trade is risk    free",
+    ],
+)
+def test_united_kings_noise_lines_ignored(line):
+    assert _clean_uk_lines(line) == []
+    assert parse_signal(line, NEW_CHAT_ID, {}) is None


### PR DESCRIPTION
## Summary
- expand `UK_NOISE_LINES` with regexes for tp almost, break even and risk free messages
- add tests ensuring these noise lines are stripped and ignored

## Testing
- `pytest tests/test_united_kings.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4659af9a88323840d5f4b4d793641