### PR TITLE
Add trade direction synonyms and tests

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -241,6 +241,14 @@ TP_VALUE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Direction synonyms used across parsers
+BUY_SYNONYMS = re.compile(
+    r"\b(?:buy|long|go\s+long|grab\s+long)\b", re.IGNORECASE
+)
+SELL_SYNONYMS = re.compile(
+    r"\b(?:sell|short|go\s+short|offload)\b", re.IGNORECASE
+)
+
 # Special-case parsing for the "United Kings" channels
 # (IDs taken from known public channels)
 UNITED_KINGS_CHAT_IDS = {
@@ -249,8 +257,6 @@ UNITED_KINGS_CHAT_IDS = {
 }
 
 # United Kings specific regex patterns
-UK_BUY_RE = re.compile(r"\b(?:buy|long)\b", re.IGNORECASE)
-UK_SELL_RE = re.compile(r"\b(?:sell|short)\b", re.IGNORECASE)
 # Entry is provided as a range separated by a dash ("@" optional, various unicode dashes)
 UK_RANGE_RE = re.compile(
     r"@?\s*(-?\d+(?:\.\d+)?)\s*[-\u2010-\u2015]\s*(-?\d+(?:\.\d+)?)"
@@ -332,9 +338,9 @@ def guess_position(text: str) -> Optional[str]:
     for raw, norm in POS_VARIANTS:
         if raw in up:
             return norm
-    if re.search(r"\bBUY\b", up):
+    if BUY_SYNONYMS.search(text or ""):
         return "Buy"
-    if re.search(r"\bSELL\b", up):
+    if SELL_SYNONYMS.search(text or ""):
         return "Sell"
     return None
 
@@ -745,9 +751,9 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Optional[str]:
     symbol = normalize_symbol("XAUUSD")
 
     position = ""
-    if any(UK_BUY_RE.search(l) for l in lines):
+    if any(BUY_SYNONYMS.search(l) for l in lines):
         position = "Buy"
-    elif any(UK_SELL_RE.search(l) for l in lines):
+    elif any(SELL_SYNONYMS.search(l) for l in lines):
         position = "Sell"
 
     if not position:

--- a/tests/test_guess_position.py
+++ b/tests/test_guess_position.py
@@ -1,0 +1,9 @@
+from signal_bot import guess_position
+
+
+def test_guess_position_buy_synonym():
+    assert guess_position("We should grab long on gold") == "Buy"
+
+
+def test_guess_position_sell_synonym():
+    assert guess_position("Time to offload some positions") == "Sell"

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -88,3 +88,15 @@ def test_united_kings_missing_position_logged(caplog):
     with caplog.at_level(logging.INFO):
         assert parse_signal_united_kings(message, 1234) is None
     assert "no position" in caplog.text.lower()
+
+
+def test_united_kings_buy_synonym():
+    message = """#XAUUSD\ngrab long\n@1900-1910\nTP1 : 1915\nSL : 1890\n"""
+    result = parse_signal_united_kings(message, 1234)
+    assert result and "Position: Buy" in result
+
+
+def test_united_kings_sell_synonym():
+    message = """#XAUUSD\noffload\n@1900-1910\nTP1 : 1890\nSL : 1915\n"""
+    result = parse_signal_united_kings(message, 1234)
+    assert result and "Position: Sell" in result


### PR DESCRIPTION
## Summary
- add global BUY_SYNONYMS and SELL_SYNONYMS regexes
- use synonyms in `guess_position` and United Kings parser
- test position detection for new synonyms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b467f95f4c83238797169493f0396c