### PR TITLE
Allow profile store path override via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ the following environment variables:
 * `SESSION_SECRET` – random string used to sign the Flask session.
 * `ADMIN_USER` – username for logging in.
 * `ADMIN_PASS` – password for logging in.
+* `PROFILE_STORE_PATH` – optional path for storing profile data (defaults to `profiles.json`).
 
 Visit `/login` and enter the credentials to access protected routes like
 `/`, `/save_config`, `/start_bot` and `/stop_bot`.
@@ -97,6 +98,7 @@ Visit `/login` and enter the credentials to access protected routes like
    * `SESSION_SECRET` – random string for Flask session security.
    * `ADMIN_USER` – username for the web dashboard.
    * `ADMIN_PASS` – password for the web dashboard.
+   * `PROFILE_STORE_PATH` – optional path for storing profile data (defaults to `profiles.json`).
 
 5. Deploy the service.  Once running, visit `/` to configure the bot if you have not set environment variables.  The dashboard allows you to start and stop the bot without redeploying.
 

--- a/app.py
+++ b/app.py
@@ -93,7 +93,8 @@ config_store = {
 # Profiles are persisted to disk using :class:`ProfileStore`.  Each
 # profile is keyed by a unique ``name`` and stores channel lists along
 # with optional parsing options.
-profiles_store = ProfileStore("profiles.json")
+profile_store_path = os.environ.get("PROFILE_STORE_PATH", "profiles.json")
+profiles_store = ProfileStore(profile_store_path)
 
 
 def _profile_to_dict(profile: ChannelProfile) -> dict:

--- a/tests/test_api_profile_test.py
+++ b/tests/test_api_profile_test.py
@@ -1,15 +1,10 @@
-import os
 import importlib
 
-os.environ.setdefault("SESSION_SECRET", "test")
 
-from profiles import ProfileStore
-
-
-def test_api_profile_test_handles_missing_profile_options(tmp_path):
+def test_api_profile_test_handles_missing_profile_options(tmp_path, monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET", "test")
+    monkeypatch.setenv("PROFILE_STORE_PATH", str(tmp_path / "profiles.json"))
     app_module = importlib.reload(importlib.import_module("app"))
-    app_module.profiles_store = ProfileStore(tmp_path / "profiles.json")
-    app_module._load_profiles_into_channel_profiles()
     app = app_module.app
     app.config["TESTING"] = True
     app.config["WTF_CSRF_ENABLED"] = False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,14 @@
 import importlib
+import tempfile
 
 
 def _load_app(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    monkeypatch.setenv("PROFILE_STORE_PATH", tmp.name)
     app = importlib.reload(importlib.import_module("app"))
     app.app.config["WTF_CSRF_ENABLED"] = False
     return app

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -3,16 +3,13 @@ import tempfile
 
 import pytest
 
-from profiles import ProfileStore
-
 
 def _load_app(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
-    app_module = importlib.reload(importlib.import_module("app"))
     tmp = tempfile.NamedTemporaryFile(delete=False)
     tmp.close()
-    app_module.profiles_store = ProfileStore(tmp.name)
-    app_module._load_profiles_into_channel_profiles()
+    monkeypatch.setenv("PROFILE_STORE_PATH", tmp.name)
+    app_module = importlib.reload(importlib.import_module("app"))
     return app_module
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,10 +1,14 @@
 import importlib
+import tempfile
 
 
 def _load_app(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    monkeypatch.setenv("PROFILE_STORE_PATH", tmp.name)
     app = importlib.reload(importlib.import_module("app"))
     app.app.config["WTF_CSRF_ENABLED"] = False
     return app

--- a/tests/test_invalid_api_id.py
+++ b/tests/test_invalid_api_id.py
@@ -1,11 +1,12 @@
 import importlib
 
 
-def test_start_bot_invalid_api_id(monkeypatch):
+def test_start_bot_invalid_api_id(monkeypatch, tmp_path):
     """Posting to /start_bot with a non-int api_id returns 400 and flashes."""
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
+    monkeypatch.setenv("PROFILE_STORE_PATH", str(tmp_path / "profiles.json"))
     app = importlib.reload(importlib.import_module("app"))
     app.app.config["WTF_CSRF_ENABLED"] = False
 

--- a/tests/test_parse_channel_numbers.py
+++ b/tests/test_parse_channel_numbers.py
@@ -3,10 +3,11 @@ import pytest
 
 
 @pytest.fixture
-def app_module(monkeypatch):
+def app_module(monkeypatch, tmp_path):
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
+    monkeypatch.setenv("PROFILE_STORE_PATH", str(tmp_path / "profiles.json"))
     return importlib.reload(importlib.import_module("app"))
 
 

--- a/tests/test_stop_bot.py
+++ b/tests/test_stop_bot.py
@@ -1,12 +1,16 @@
 import asyncio
 from concurrent.futures import Future
 import importlib
+import tempfile
 
 
 def test_stop_bot_route_disconnects_cleanly(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    monkeypatch.setenv("PROFILE_STORE_PATH", tmp.name)
     app = importlib.reload(importlib.import_module("app"))
     app.app.config["WTF_CSRF_ENABLED"] = False
 
@@ -57,6 +61,9 @@ def test_stop_bot_no_loop_does_not_crash(monkeypatch):
     monkeypatch.setenv("SESSION_SECRET", "test")
     monkeypatch.setenv("ADMIN_USER", "u")
     monkeypatch.setenv("ADMIN_PASS", "p")
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    monkeypatch.setenv("PROFILE_STORE_PATH", tmp.name)
     app = importlib.reload(importlib.import_module("app"))
     app.app.config["WTF_CSRF_ENABLED"] = False
 


### PR DESCRIPTION
## Summary
- Allow setting profile store path via `PROFILE_STORE_PATH` environment variable
- Document `PROFILE_STORE_PATH` usage in README
- Update tests to configure `PROFILE_STORE_PATH` when using temporary profiles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b469c1054c832398fbc06b81efc483