### PR TITLE
Expand buy/sell verb patterns and test new United Kings verbs

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -246,10 +246,12 @@ TP_VALUE_RE = re.compile(
 
 # Direction synonyms used across parsers
 BUY_SYNONYMS = re.compile(
-    r"\b(?:buy|long|go\s+long|grab\s+long)\b", re.IGNORECASE
+    r"\b(?:buy|long|go\s+long|grab(?:\s+long)?|purchase|acquire|accumulate|pick\s*up|load\s*up)\b",
+    re.IGNORECASE,
 )
 SELL_SYNONYMS = re.compile(
-    r"\b(?:sell|short|go\s+short|offload)\b", re.IGNORECASE
+    r"\b(?:sell|short|go\s+short|offload|unload|dump|liquidate|dispose)\b",
+    re.IGNORECASE,
 )
 
 # Special-case parsing for the "United Kings" channels

--- a/tests/test_guess_position.py
+++ b/tests/test_guess_position.py
@@ -7,3 +7,11 @@ def test_guess_position_buy_synonym():
 
 def test_guess_position_sell_synonym():
     assert guess_position("Time to offload some positions") == "Sell"
+
+
+def test_guess_position_purchase_synonym():
+    assert guess_position("Let's purchase more gold") == "Buy"
+
+
+def test_guess_position_dump_synonym():
+    assert guess_position("Better dump those positions") == "Sell"

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -97,13 +97,31 @@ def test_united_kings_missing_position_logged(caplog):
     assert "no position" in caplog.text.lower()
 
 
-def test_united_kings_buy_synonym():
-    message = """#XAUUSD\ngrab long\n@1900-1910\nTP1 : 1915\nSL : 1890\n"""
+def test_united_kings_buy_synonym_grab():
+    message = """#XAUUSD\ngrab\n@1900-1910\nTP1 : 1915\nSL : 1890\n"""
     result = parse_signal_united_kings(message, 1234)
     assert result and "Position: Buy" in result
 
 
-def test_united_kings_sell_synonym():
+def test_united_kings_buy_synonym_purchase():
+    message = """#XAUUSD\npurchase\n@1900-1910\nTP1 : 1915\nSL : 1890\n"""
+    result = parse_signal_united_kings(message, 1234)
+    assert result and "Position: Buy" in result
+
+
+def test_united_kings_sell_synonym_offload():
     message = """#XAUUSD\noffload\n@1900-1910\nTP1 : 1890\nSL : 1915\n"""
+    result = parse_signal_united_kings(message, 1234)
+    assert result and "Position: Sell" in result
+
+
+def test_united_kings_sell_synonym_unload():
+    message = """#XAUUSD\nunload\n@1900-1910\nTP1 : 1890\nSL : 1915\n"""
+    result = parse_signal_united_kings(message, 1234)
+    assert result and "Position: Sell" in result
+
+
+def test_united_kings_sell_synonym_dump():
+    message = """#XAUUSD\ndump\n@1900-1910\nTP1 : 1890\nSL : 1915\n"""
     result = parse_signal_united_kings(message, 1234)
     assert result and "Position: Sell" in result


### PR DESCRIPTION
## Summary
- extend buy/sell regex patterns with additional synonyms like purchase, grab, unload, dump, and other common verbs
- verify parsing of United Kings messages using new verbs
- cover new verbs in guess_position tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46cd22d448323aaa3a3803a7adbf5