### PR TITLE
Refine stop loss extraction with keyword-aware regex

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -234,8 +234,13 @@ EMOJI_RE = re.compile(
 DIVIDER_LINE_RE = re.compile(r"^[\s\-\–\—\_\=\·\.\•\*➖]+$")
 
 TP_KEYS = ["tp", "take profit", "take-profit", "t/p", "t p"]
-SL_KEYS = ["sl", "stop loss", "stop-loss", "s/l", "s l"]
 ENTRY_KEYS = ["entry price", "entry", "e:"]
+
+# الگوی استخراج عدد پس از SL یا Stop Loss
+SL_VALUE_RE = re.compile(
+    r"\b(?:SL|Stop[-\s]*Loss)\s*[:\-]?\s*(-?\d+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
 
 # Explicit TP/Target line detector and numeric extractor excluding unit-suffixed numbers
 TP_LINE_RE = re.compile(r"\b(?:tp\d*|target)\b", re.IGNORECASE)
@@ -388,11 +393,17 @@ extract_entry = classic_extract_entry
 
 
 def extract_sl(lines: List[str]) -> Optional[str]:
+    """Extract the stop loss value from signal lines.
+
+    Only numbers that immediately follow an ``SL`` or ``Stop Loss`` keyword
+    are considered. Lines containing the keyword without a subsequent number
+    are ignored to avoid accidentally capturing unrelated numeric values.
+    """
+
     for l in lines:
-        if any(k in l.lower() for k in SL_KEYS):
-            m = NUM_RE.search(l)
-            if m:
-                return m.group(1)
+        m = SL_VALUE_RE.search(l)
+        if m:
+            return m.group(1)
     return None
 
 

--- a/tests/test_extract_sl.py
+++ b/tests/test_extract_sl.py
@@ -1,0 +1,16 @@
+import pytest
+from signal_bot import extract_sl
+
+
+@pytest.mark.parametrize("lines, expected", [
+    (["Buy 1.2345 TP 1.2400 SL 1.2320"], "1.2320"),
+    (["Entry Price 1.2345, Stop Loss 1.2320"], "1.2320"),
+    (["SL 1.2320 Entry 1.2345"], "1.2320"),
+])
+def test_extract_sl_entry_and_sl_same_line(lines, expected):
+    assert extract_sl(lines) == expected
+
+
+def test_extract_sl_ignores_sl_without_number():
+    lines = ["Buy 1.2345 SL", "TP1 1.2400"]
+    assert extract_sl(lines) is None


### PR DESCRIPTION
## Summary
- Improve stop-loss parsing by capturing numbers only when they follow `SL` or `Stop Loss`
- Skip lines missing numeric stop-loss values to avoid misinterpretation
- Add tests for cases where entry and stop loss appear on the same line

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b46ceb55c08323859b4efb8525c830