### PR TITLE
Use regex synonyms for position detection

### DIFF
--- a/tests/test_parse_signal_synonyms.py
+++ b/tests/test_parse_signal_synonyms.py
@@ -1,0 +1,16 @@
+import pytest
+from signal_bot import parse_signal
+
+
+@pytest.mark.parametrize("verb", ["purchase", "grab", "long"])
+def test_parse_signal_buy_synonyms(verb):
+    message = f"#XAUUSD\n{verb}\nEntry Price : 1900\nTP1 : 1910\nStop Loss : 1890"
+    result = parse_signal(message, 1234, {})
+    assert result and "Position: Buy" in result
+
+
+@pytest.mark.parametrize("verb", ["offload", "unload", "dump", "short"])
+def test_parse_signal_sell_synonyms(verb):
+    message = f"#XAUUSD\n{verb}\nEntry Price : 1900\nTP1 : 1890\nStop Loss : 1910"
+    result = parse_signal(message, 1234, {})
+    assert result and "Position: Sell" in result


### PR DESCRIPTION
## Summary
- Add BUY_SYNONYMS and SELL_SYNONYMS regex patterns for direction detection
- Rework noise stripping and United Kings parser to use regex-based position guessing
- Test parsing for buy/sell verbs like purchase, grab, offload, unload, dump

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b46dd29f548323ac7f97bd81636070