### PR TITLE
Add XAU alias to symbol normalization

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -92,6 +92,7 @@ CURRENCY_CODES = {
 ALIAS_MAP = {
     # Commodities
     "GOLD": "XAUUSD",
+    "XAU": "XAUUSD",
     "SILVER": "XAGUSD",
     "WTI": "USOIL",
     "USOIL": "USOIL",

--- a/tests/test_normalize_symbol.py
+++ b/tests/test_normalize_symbol.py
@@ -1,0 +1,5 @@
+from signal_bot import normalize_symbol
+
+
+def test_normalize_symbol_xau():
+    assert normalize_symbol("XAU") == "XAUUSD"


### PR DESCRIPTION
## Summary
- map `XAU` shorthand to `XAUUSD` in `ALIAS_MAP`
- test that `normalize_symbol` converts `XAU` to `XAUUSD`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b472e692b083239bedd95fa2025219