### PR TITLE
Expand trade direction synonyms

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -248,8 +248,11 @@ TP_VALUE_RE = re.compile(
 )
 
 # Direction synonyms used across parsers
-BUY_SYNONYMS = re.compile(r"\b(buy|long|purchase|grab)\b", re.IGNORECASE)
-SELL_SYNONYMS = re.compile(r"\b(sell|short|offload|unload|dump)\b", re.IGNORECASE)
+BUY_TERMS = ["buy", "buying", "long", "purchase", "grab"]
+SELL_TERMS = ["sell", "selling", "short", "offload", "unload", "dump", "ditch"]
+
+BUY_SYNONYMS = re.compile(rf"\b({'|'.join(BUY_TERMS)})\b", re.IGNORECASE)
+SELL_SYNONYMS = re.compile(rf"\b({'|'.join(SELL_TERMS)})\b", re.IGNORECASE)
 
 # Special-case parsing for the "United Kings" channels
 # (IDs taken from known public channels)
@@ -278,7 +281,7 @@ UK_NOISE_LINES = [
 UK_GOLD_RE = re.compile(r"\bgold\b", re.IGNORECASE)
 UK_PRICE_RE = re.compile(r"@\s*-?\d+(?:\.\d+)?")
 UK_ACTION_RE = re.compile(
-    r"(?:\b(?:buy|sell|grab|purchase|unload)\b|we(?:'|’)?re\s+(?:buying|selling))",
+    rf"\b({'|'.join(BUY_TERMS + SELL_TERMS)})\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -136,6 +136,20 @@ def test_united_kings_sell_synonym_dump():
     assert reason is None
 
 
+def test_united_kings_sell_phrase_were_selling():
+    message = """#XAUUSD\nwe’re selling\n@1900-1910\nTP1 : 1890\nSL : 1915\n"""
+    result, reason = parse_signal_united_kings(message, 1234)
+    assert result and "Position: Sell" in result
+    assert reason is None
+
+
+def test_united_kings_sell_synonym_ditch():
+    message = """#XAUUSD\nditch\n@1900-1910\nTP1 : 1890\nSL : 1915\n"""
+    result, reason = parse_signal_united_kings(message, 1234)
+    assert result and "Position: Sell" in result
+    assert reason is None
+
+
 def test_united_kings_fallback_to_classic():
     message = (
         "#XAUUSD\nBuy\nEntry Price : 1932\nTP1 : 1935\nTP2 : 1940\nStop Loss : 1925\n"


### PR DESCRIPTION
## Summary
- include "buying" and "selling"/"ditch" in trade direction synonyms
- build UK action regex from shared synonym lists
- test United Kings parser with "we’re selling" and "ditch"

## Testing
- `pytest tests/test_guess_position.py tests/test_parse_signal_synonyms.py tests/test_parse_united_kings.py`


------
https://chatgpt.com/codex/tasks/task_e_68b472e7b1048323b419c37679e6b760