### PR TITLE
Prioritize local direction in UK parser

### DIFF
--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -157,3 +157,13 @@ def test_united_kings_fallback_to_classic():
     chat_id = next(iter(signal_bot.UNITED_KINGS_CHAT_IDS))
     result = parse_signal(message, chat_id, {})
     assert result and "Position: Buy" in result
+
+
+def test_united_kings_direction_window_priority():
+    filler = "x" * 130
+    message = (
+        f"#XAUUSD\nSell {filler}\nBuy\n@1900-1910\nTP1 : 1915\nSL : 1890\n"
+    )
+    result, reason = parse_signal_united_kings(message, 1234)
+    assert result and "Position: Buy" in result
+    assert reason is None


### PR DESCRIPTION
## Summary
- infer position from a 120-char window around the entry range in United Kings messages
- fall back to global search if no direction found locally
- add regression test ensuring distant opposite keywords don't mislead direction detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47866882483239ce63111f8fed8f5