### PR TITLE
Reject sell SL within entry range

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -758,18 +758,24 @@ def _validate_tp_sl(
             if entry_range and (any(lo <= tv <= hi for tv in tp_vals) or lo <= sl_v <= hi):
                 log.warning("TP/SL inside entry range")
         elif pos.startswith("SELL"):
-            boundary = lo if entry_range else e
+            boundary = hi if entry_range else e
+            if entry_range and lo <= sl_v <= hi:
+                log.info(
+                    f"IGNORED (sell but SL {sl} inside entry range {entry_range[0]}-{entry_range[1]})"
+                )
+                return False
             if sl_v <= boundary:
                 log.info(f"IGNORED (sell but SL {sl} <= entry {entry})")
                 return False
-            if any(tv > boundary for tv in tp_vals):
+            tp_boundary = lo if entry_range else e
+            if any(tv > tp_boundary for tv in tp_vals):
                 log.info(f"IGNORED (sell but TP {tp_vals[0]} > entry {entry})")
                 return False
-            if all(tv > boundary for tv in tp_vals):
+            if all(tv > tp_boundary for tv in tp_vals):
                 log.info(f"IGNORED (sell but all TP > entry {entry})")
                 return False
-            if entry_range and (any(lo <= tv <= hi for tv in tp_vals) or lo <= sl_v <= hi):
-                log.warning("TP/SL inside entry range")
+            if entry_range and any(lo <= tv <= hi for tv in tp_vals):
+                log.warning("TP inside entry range")
     except Exception:
         pass
     return True

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -16,9 +16,9 @@ VALID_SIGNALS = [
 📊 #XAUUSD\n📉 Position: Buy\n❗️ R/R : 1/1.5\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1915\n✔️ TP2 : 1920\n🚫 Stop Loss : 1890""",
     ),
     (
-        """#XAUUSD\nSell gold\n@1900-1910\nTP1 : 1890\nTP2 : 1880\nSL : 1910\n""",
+        """#XAUUSD\nSell gold\n@1900-1910\nTP1 : 1890\nTP2 : 1880\nSL : 1915\n""",
         """\
-📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1/1\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1910""",
+📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1.5/1\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1915""",
     ),
 ]
 
@@ -70,6 +70,13 @@ def test_parse_united_kings_noise(message):
 
 def test_parse_united_kings_tp_equal_entry():
     message = """#XAUUSD\nBuy gold\n@1900-1910\nTP1 : 1900\nTP2 : 1915\nSL : 1890\n"""
+    res, reason = parse_signal_united_kings(message, 1234)
+    assert res is None
+    assert reason == "invalid"
+
+
+def test_united_kings_sell_sl_inside_range_rejected():
+    message = """#XAUUSD\nSell\n@1900-1910\nTP1 : 1890\nSL : 1905\n"""
     res, reason = parse_signal_united_kings(message, 1234)
     assert res is None
     assert reason == "invalid"


### PR DESCRIPTION
## Summary
- ensure sell signals with an entry range validate SL against the upper bound and reject stop losses that fall inside that range
- add coverage for sell SL inside range and update sample sell signal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b478678bc88323b6dbb14e614aa23d