### PR TITLE
Handle entry-less United Kings signals with entry ranges

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -572,10 +572,11 @@ def _strip_noise_lines(lines: list[str]) -> list[str]:
 
 
 def is_valid(signal: Dict) -> bool:
+    entry_or_range = signal.get("entry") or signal.get("extra", {}).get("entries", {}).get("range")
     return all([
         signal.get("symbol"),
         signal.get("position"),
-        signal.get("entry"),
+        entry_or_range,
         signal.get("sl"),
     ]) and len(signal.get("tps", [])) >= 1
 
@@ -755,8 +756,11 @@ def _validate_tp_sl(
             if all(tv < (hi if entry_range else e) for tv in tp_vals):
                 log.info(f"IGNORED (buy but all TP < entry {entry})")
                 return False
-            if entry_range and (any(lo <= tv <= hi for tv in tp_vals) or lo <= sl_v <= hi):
+            if entry_range and (
+                any(lo <= tv <= hi for tv in tp_vals) or lo < sl_v < hi
+            ):
                 log.warning("TP/SL inside entry range")
+                return False
         elif pos.startswith("SELL"):
             boundary = lo if entry_range else e
             if sl_v <= boundary:
@@ -768,8 +772,11 @@ def _validate_tp_sl(
             if all(tv > boundary for tv in tp_vals):
                 log.info(f"IGNORED (sell but all TP > entry {entry})")
                 return False
-            if entry_range and (any(lo <= tv <= hi for tv in tp_vals) or lo <= sl_v <= hi):
+            if entry_range and (
+                any(lo <= tv <= hi for tv in tp_vals) or lo < sl_v < hi
+            ):
                 log.warning("TP/SL inside entry range")
+                return False
     except Exception:
         pass
     return True
@@ -832,10 +839,10 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Tuple[Optional[str], O
 
     range_str = m.group(0)
     if "@" in range_str:
-        entry = f"{lo}"
+        calc_entry = f"{lo}"
     else:
         mid = (lo + hi) / 2
-        entry = _fmt(mid)
+        calc_entry = _fmt(mid)
     entry_range = [_fmt(lo), _fmt(hi)]
 
     # SL
@@ -861,13 +868,16 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Tuple[Optional[str], O
 
     rr = extract_rr(text)
     if not rr:
-        rr = calculate_rr(entry, sl, tps[0])
+        rr = calculate_rr(calc_entry, sl, tps[0])
 
-    extra = {"entries": {"range": entry_range}}
+    extra = {
+        "entries": {"range": entry_range},
+        "show_entry_range_only": True,
+    }
     signal = {
         "symbol": symbol,
         "position": position,
-        "entry": entry,
+        "entry": None,
         "sl": sl,
         "tps": tps,
         "rr": rr,
@@ -878,7 +888,7 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Tuple[Optional[str], O
         return None, "invalid"
     if not validate_directional_consistency(signal):
         return None, "invalid"
-    if not _validate_tp_sl(position, entry, sl, tps, tuple(entry_range)):
+    if not _validate_tp_sl(position, calc_entry, sl, tps, tuple(entry_range)):
         return None, "invalid"
 
     return to_unified(signal, chat_id, extra), None

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -13,12 +13,12 @@ VALID_SIGNALS = [
     (
         """#XAUUSD\nBuy gold\n@1900-1910\nTP1 : 1915\nTP2 : 1920\nSL : 1890\n""",
         """\
-📊 #XAUUSD\n📉 Position: Buy\n❗️ R/R : 1/1.5\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1915\n✔️ TP2 : 1920\n🚫 Stop Loss : 1890""",
+📊 #XAUUSD\n📉 Position: Buy\n❗️ R/R : 1/1.5\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1915\n✔️ TP2 : 1920\n🚫 Stop Loss : 1890""",
     ),
     (
         """#XAUUSD\nSell gold\n@1900-1910\nTP1 : 1890\nTP2 : 1880\nSL : 1910\n""",
         """\
-📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1/1\n💲 Entry Price : 1900.0\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1910""",
+📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1/1\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1910""",
     ),
 ]
 
@@ -88,8 +88,9 @@ def test_united_kings_entry_range_assignment(monkeypatch):
     message = """#XAUUSD\nBuy\n@1900-1910\nTP1 : 1915\nSL : 1890\n"""
     parse_signal_united_kings(message, 1234)
 
-    assert captured["signal"]["entry"] == "1900.0"
+    assert captured["signal"]["entry"] is None
     assert captured["extra"]["entries"]["range"] == ["1900", "1910"]
+    assert captured["extra"].get("show_entry_range_only") is True
 
 
 def test_united_kings_missing_position_logged(caplog):

--- a/tests/test_united_kings.py
+++ b/tests/test_united_kings.py
@@ -19,7 +19,6 @@ EXPECTED = """\
 📊 #XAUUSD
 📉 Position: Buy
 ❗️ R/R : 1/1.5
-💲 Entry Price : 1900.0
 🎯 Entry Range : 1900 – 1910
 ✔️ TP1 : 1915
 ✔️ TP2 : 1920


### PR DESCRIPTION
## Summary
- accept United Kings messages that only supply an entry range
- validate TP/SL against entry ranges and treat TP/SL inside the range as invalid
- adjust United Kings tests to expect no explicit entry price

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47867fd748323aeea32af0e21fe8a