### PR TITLE
Allow currency sign for stop loss value

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -237,7 +237,7 @@ ENTRY_KEYS = ["entry price", "entry", "e:"]
 
 # الگوی استخراج عدد پس از SL یا Stop Loss
 SL_VALUE_RE = re.compile(
-    r"\b(?:SL|Stop[-\s]*Loss)\s*[:\-]?\s*(-?\d+(?:\.\d+)?)",
+    r"\b(?:SL|Stop[-\s]*Loss)\s*[:\-]?\s*[$€£]?\s*(-?\d+(?:\.\d+)?)",
     re.IGNORECASE,
 )
 

--- a/tests/test_extract_sl.py
+++ b/tests/test_extract_sl.py
@@ -14,3 +14,8 @@ def test_extract_sl_entry_and_sl_same_line(lines, expected):
 def test_extract_sl_ignores_sl_without_number():
     lines = ["Buy 1.2345 SL", "TP1 1.2400"]
     assert extract_sl(lines) is None
+
+
+def test_extract_sl_allows_currency_symbol():
+    lines = ["Stop Loss : $3297"]
+    assert extract_sl(lines) == "3297"


### PR DESCRIPTION
## Summary
- allow `SL` regex to accept optional currency symbol after colon
- test stop loss extraction when value prefixed by `$`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4818f9d248323bbcca9be88db5adf