### PR TITLE
Add OIL alias and unit test

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -95,6 +95,7 @@ ALIAS_MAP = {
     "XAU": "XAUUSD",
     "SILVER": "XAGUSD",
     "WTI": "USOIL",
+    "OIL": "USOIL",
     "USOIL": "USOIL",
     "UKOIL": "UKOIL",
     "BRENT": "UKOIL",

--- a/tests/test_normalize_symbol.py
+++ b/tests/test_normalize_symbol.py
@@ -3,3 +3,7 @@ from signal_bot import normalize_symbol
 
 def test_normalize_symbol_xau():
     assert normalize_symbol("XAU") == "XAUUSD"
+
+
+def test_normalize_symbol_oil():
+    assert normalize_symbol("OIL") == "USOIL"


### PR DESCRIPTION
## Summary
- add commodity alias mapping for OIL -> USOIL
- add unit test covering OIL normalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48365f06c8323abb4a0cc6f51cfdc