### PR TITLE
Add source-specific parsers and routing for source names

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -146,6 +146,12 @@ RR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Timeframe (TF)
+TF_RE = re.compile(
+    r"\b(?:TF|Time\s*Frame|Timeframe)\s*[:\-]?\s*([0-9]+[A-Za-z]+)",
+    re.IGNORECASE,
+)
+
 # حالت‌های پوزیشن
 POS_VARIANTS = [
     ("BUY LIMIT", "Buy Limit"),
@@ -488,6 +494,14 @@ def extract_rr(text: str) -> Optional[str]:
     m = RR_RE.search(text or "")
     if m:
         return f"{m.group(2)}/{m.group(3)}"
+    return None
+
+
+def extract_tf(text: str) -> Optional[str]:
+    """Extract timeframe (TF) string from *text*."""
+    m = TF_RE.search(text or "")
+    if m:
+        return m.group(1).upper()
     return None
 
 
@@ -1061,6 +1075,48 @@ def parse_signal(
 
     return parse_signal_classic(text, chat_id, profile=profile, return_meta=return_meta)
 
+# -----------------------------------------------------------------------------
+# Source-specific parsers
+# -----------------------------------------------------------------------------
+
+
+def _parse_with_tf(text: str):
+    """Helper to parse a message using classic rules and extract timeframe."""
+    parsed = parse_signal_classic(text, 0, {}, return_meta=True)
+    if not parsed:
+        return None
+    formatted, meta = parsed
+    tf = extract_tf(text)
+    if tf:
+        formatted += f"\n⏳ TF : {tf}"
+        meta["tf"] = tf
+    return formatted, meta
+
+
+def parse_gold_exclusive(text: str):
+    return _parse_with_tf(text)
+
+
+def parse_lingrid(text: str):
+    return _parse_with_tf(text)
+
+
+def parse_forex_rr(text: str):
+    return _parse_with_tf(text)
+
+
+def parse_message_by_source(text: str, source_name: str):
+    """Select parser based on *source_name* and return parsed result."""
+    name = (source_name or "").lower()
+    if "gold" in name and "exclusive" in name:
+        return parse_gold_exclusive(text)
+    if "lingrid" in name:
+        return parse_lingrid(text)
+    if "forex" in name and "rr" in name:
+        return parse_forex_rr(text)
+    return None
+
+
 # ----------------------------------------------------------------------------
 # Dedupe helper — اثرانگشت محتوا
 # ----------------------------------------------------------------------------
@@ -1355,7 +1411,15 @@ class SignalBot:
                 return
 
             profile = resolve_profile(int(event.chat_id))
-            parsed = parse_signal(text, event.chat_id, profile, return_meta=True)
+            source_name = ""
+            chat_obj = getattr(event, "chat", None)
+            if chat_obj is not None:
+                source_name = getattr(chat_obj, "title", "") or getattr(chat_obj, "username", "")
+            parsed = None
+            if source_name:
+                parsed = parse_message_by_source(text, source_name)
+            if not parsed:
+                parsed = parse_signal(text, event.chat_id, profile, return_meta=True)
             if not parsed:
                 log.info(f"Rejecting message from {event.chat_id}: {snippet}")
                 self.stats.increment("rejected")

--- a/tests/test_parse_sources.py
+++ b/tests/test_parse_sources.py
@@ -1,0 +1,69 @@
+import pytest
+from signal_bot import (
+    parse_gold_exclusive,
+    parse_lingrid,
+    parse_forex_rr,
+    parse_message_by_source,
+)
+
+
+def test_parse_gold_exclusive():
+    message = """#XAUUSD\nBuy\nEntry 1900\nSL 1890\nTP 1910\nR/R 1/2\nTF 1H\n"""
+    expected = """\
+📊 #XAUUSD
+📉 Position: Buy
+❗️ R/R : 1/2
+💲 Entry Price : 1900
+✔️ TP1 : 1910
+🚫 Stop Loss : 1890
+⏳ TF : 1H"""
+    result, meta = parse_gold_exclusive(message)
+    assert result == expected
+    assert meta["symbol"] == "XAUUSD"
+    assert meta["position"] == "Buy"
+    assert meta["rr"] == "1/2"
+    assert meta["tf"] == "1H"
+
+
+def test_parse_lingrid():
+    message = """#EURUSD\nSell\nEntry 1.1000\nSL 1.1050\nTP 1.0950\nR/R 1/2\nTime Frame 1H\n"""
+    expected = """\
+📊 #EURUSD
+📉 Position: Sell
+❗️ R/R : 1/2
+💲 Entry Price : 1.1000
+✔️ TP1 : 1.0950
+🚫 Stop Loss : 1.1050
+⏳ TF : 1H"""
+    result, meta = parse_lingrid(message)
+    assert result == expected
+    assert meta["symbol"] == "EURUSD"
+    assert meta["position"] == "Sell"
+    assert meta["tf"] == "1H"
+
+
+def test_parse_forex_rr():
+    message = """#GBPUSD\nBuy\nEntry 1.3000\nSL 1.2950\nTP 1.3100\nR/R 1/2\nTF 30M\n"""
+    expected = """\
+📊 #GBPUSD
+📉 Position: Buy
+❗️ R/R : 1/2
+💲 Entry Price : 1.3000
+✔️ TP1 : 1.3100
+🚫 Stop Loss : 1.2950
+⏳ TF : 30M"""
+    result, meta = parse_forex_rr(message)
+    assert result == expected
+    assert meta["symbol"] == "GBPUSD"
+    assert meta["position"] == "Buy"
+    assert meta["tf"] == "30M"
+
+
+def test_parse_message_by_source_routing():
+    msg = "#XAUUSD\nBuy\nEntry 1900\nSL 1890\nTP 1910\nR/R 1/2\nTF 1H\n"
+    assert parse_message_by_source(msg, "Gold Exclusive")[0] == parse_gold_exclusive(msg)[0]
+    msg2 = "#EURUSD\nSell\nEntry 1.1000\nSL 1.1050\nTP 1.0950\nR/R 1/2\nTF 1H\n"
+    assert parse_message_by_source(msg2, "Lingrid")[0] == parse_lingrid(msg2)[0]
+    msg3 = "#GBPUSD\nBuy\nEntry 1.3000\nSL 1.2950\nTP 1.3100\nR/R 1/2\nTF 30M\n"
+    assert parse_message_by_source(msg3, "Forex RR")[0] == parse_forex_rr(msg3)[0]
+    assert parse_message_by_source(msg3, "Unknown") is None


### PR DESCRIPTION
## Summary
- add timeframe extraction and source-specific parsers for Gold Exclusive, Lingrid, and Forex RR channels
- route messages to specialized parsers based on source name
- cover new parsers and routing with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4836882a0832396e17d068e0f262d