### PR TITLE
Add High-Risk note parsing

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -166,7 +166,6 @@ NON_SIGNAL_HINTS = [
     "result so far",
     "screenshots",
     "cheers",
-    "high-risk setup",
     "move sl",
     "put your sl",
     "risk free",
@@ -562,6 +561,7 @@ def _strip_noise_lines(lines: list[str]) -> list[str]:
                 or re.search(r"\b(buy|sell|entry|position)\b", low)
                 or BUY_SYNONYMS.search(raw)
                 or SELL_SYNONYMS.search(raw)
+                or re.search(r"high[- ]?risk", low)
             ):
                 cleaned.append(raw)
             continue
@@ -569,6 +569,13 @@ def _strip_noise_lines(lines: list[str]) -> list[str]:
         cleaned.append(raw)
 
     return cleaned
+
+
+def _extract_notes(text: str) -> List[str]:
+    notes: List[str] = []
+    if re.search(r"high[- ]?risk", text, re.IGNORECASE):
+        notes.append("High-Risk")
+    return notes
 
 
 def is_valid(signal: Dict) -> bool:
@@ -810,6 +817,7 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Tuple[Optional[str], O
     if looks_like_update(text):
         return None, "update/noise"
 
+    notes = _extract_notes(text)
     lines = _clean_uk_lines(text)
     if not lines:
         return None, "empty"
@@ -888,6 +896,7 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Tuple[Optional[str], O
         "tps": tps,
         "rr": rr,
         "extra": extra,
+        "notes": notes,
     }
 
     if not is_valid(signal):
@@ -900,7 +909,9 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Tuple[Optional[str], O
     return to_unified(signal, chat_id, extra), None
 
 
-def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
+def parse_channel_four(
+    text: str, chat_id: int, *, return_meta: bool = False
+) -> Optional[Union[str, Tuple[str, Dict[str, Any]]]]:
     """Parser for Channel Four style messages supporting entry ranges."""
     if looks_like_update(text):
         log.info("IGNORED (update/noise)")
@@ -934,6 +945,7 @@ def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
                     entry = m.group(1)
                 break
 
+    notes = _extract_notes(text)
     signal = {
         "symbol": symbol,
         "position": position,
@@ -942,6 +954,7 @@ def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
         "tps": tps,
         "rr": rr,
         "extra": {},
+        "notes": notes,
     }
     if entry_range:
         signal["extra"]["entries"] = {"range": entry_range}
@@ -954,7 +967,10 @@ def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
     if not _validate_tp_sl(position, entry, sl, tps, entry_range):
         return None
 
-    return to_unified(signal, chat_id, signal.get("extra", {}))
+    result = to_unified(signal, chat_id, signal.get("extra", {}))
+    if return_meta:
+        return result, signal
+    return result
 
 
 def parse_signal_classic(
@@ -966,6 +982,7 @@ def parse_signal_classic(
 ) -> Optional[Union[str, Tuple[str, Dict[str, Any]]]]:
     profile = profile or {}
     text = normalize_numbers(text)
+    notes = _extract_notes(text)
     if not text:
         log.info("IGNORED (empty)")
         return None
@@ -983,7 +1000,7 @@ def parse_signal_classic(
     if _has_entry_range(text):
         if profile.get("allow_entry_range"):
             try:
-                return parse_channel_four(text, chat_id)
+                return parse_channel_four(text, chat_id, return_meta=return_meta)
             except Exception as e:
                 log.debug(f"Entry range parser failed: {e}")
                 return None
@@ -1010,6 +1027,7 @@ def parse_signal_classic(
         "sl": sl,
         "tps": tps,
         "rr": rr,
+        "notes": notes,
     }
 
     if not is_valid(signal):

--- a/tests/test_high_risk_notes.py
+++ b/tests/test_high_risk_notes.py
@@ -1,0 +1,13 @@
+import pytest
+from signal_bot import parse_signal, looks_like_noise_or_update
+
+
+def test_high_risk_not_noise():
+    message = "#XAUUSD\nBuy\nHigh-Risk\nEntry Price : 1900\nTP1 : 1910\nStop Loss : 1890"
+    result, meta = parse_signal(message, 1234, {}, return_meta=True)
+    assert result is not None
+    assert meta["notes"] == ["High-Risk"]
+
+
+def test_high_risk_keyword_not_flagged():
+    assert not looks_like_noise_or_update("High-Risk")


### PR DESCRIPTION
## Summary
- detect "High-Risk" lines and attach `"High-Risk"` note to parsed signals
- ensure high-risk notices aren't filtered as noise
- test high-risk messages yield proper notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4836969a483239c7acce2ac1b62b0