### PR TITLE
Add metadata to signal parsers and strengthen validation

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -575,7 +575,7 @@ def _strip_noise_lines(lines: list[str]) -> list[str]:
 
 
 def is_valid(signal: Dict) -> bool:
-    entry_or_range = signal.get("entry") or signal.get("extra", {}).get("entries", {}).get("range")
+    entry_or_range = signal.get("entry") or signal.get("entry_range")
     return all([
         signal.get("symbol"),
         signal.get("position"),
@@ -590,11 +590,18 @@ def validate_directional_consistency(signal: Dict) -> bool:
     For ``BUY`` signals every take-profit target must be strictly above the
     entry price while the stop loss must be below it.  ``SELL`` signals require
     the opposite relationship.  If values cannot be parsed as floats the
-    function defaults to ``True`` leaving validation to other layers.
+    function defaults to ``True`` leaving validation to other layers.  When an
+    entry range is supplied the lower bound is used for stop-loss validation and
+    the upper bound for take-profit checks.
     """
 
     try:
-        entry = float(signal.get("entry"))
+        if signal.get("entry_range"):
+            lo, hi = sorted(float(x) for x in signal["entry_range"])
+            entry = (lo + hi) / 2
+        else:
+            entry = float(signal.get("entry"))
+            lo = hi = entry
         sl = float(signal.get("sl"))
         tps = [float(tp) for tp in signal.get("tps", [])]
     except Exception:
@@ -602,25 +609,25 @@ def validate_directional_consistency(signal: Dict) -> bool:
 
     pos = (signal.get("position") or "").upper()
     if pos.startswith("BUY"):
-        if sl >= entry:
+        if sl >= lo:
             log.info(
-                f"IGNORED (buy but SL {signal['sl']} >= entry {signal['entry']})"
+                f"IGNORED (buy but SL {signal['sl']} >= entry {lo})",
             )
             return False
-        if any(tp <= entry for tp in tps):
+        if any(tp <= hi for tp in tps):
             log.info(
-                f"IGNORED (buy but TP {tps[0]} <= entry {signal['entry']})"
+                f"IGNORED (buy but TP {tps[0]} <= entry {hi})",
             )
             return False
     elif pos.startswith("SELL"):
-        if sl <= entry:
+        if sl <= lo:
             log.info(
-                f"IGNORED (sell but SL {signal['sl']} <= entry {signal['entry']})"
+                f"IGNORED (sell but SL {signal['sl']} <= entry {lo})",
             )
             return False
-        if any(tp >= entry for tp in tps):
+        if any(tp >= lo for tp in tps):
             log.info(
-                f"IGNORED (sell but TP {tps[0]} >= entry {signal['entry']})"
+                f"IGNORED (sell but TP {tps[0]} >= entry {lo})",
             )
             return False
     return True
@@ -645,7 +652,7 @@ def to_unified(signal: Dict, chat_id: int, extra: Optional[Dict] = None) -> str:
     if rr:
         parts.append(f"❗️ R/R : {rr}")
 
-    entry_range = extra.get("entries", {}).get("range")
+    entry_range = signal.get("entry_range")
     if entry_range:
         if not show_range_only:
             parts.append(f"💲 Entry Price : {signal['entry']}")
@@ -879,17 +886,18 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Tuple[Optional[str], O
     if not rr:
         rr = calculate_rr(calc_entry, sl, tps[0])
 
-    extra = {
-        "entries": {"range": entry_range},
-        "show_entry_range_only": True,
-    }
+    extra = {"show_entry_range_only": True}
     signal = {
         "symbol": symbol,
         "position": position,
-        "entry": None,
+        "entry": calc_entry,
         "sl": sl,
         "tps": tps,
         "rr": rr,
+        "source": None,
+        "tf": None,
+        "entry_range": entry_range,
+        "notes": [],
         "extra": extra,
     }
 
@@ -897,13 +905,15 @@ def parse_signal_united_kings(text: str, chat_id: int) -> Tuple[Optional[str], O
         return None, "invalid"
     if not validate_directional_consistency(signal):
         return None, "invalid"
-    if not _validate_tp_sl(position, calc_entry, sl, tps, tuple(entry_range)):
+    if not _validate_tp_sl(position, calc_entry, sl, tps, tuple(signal["entry_range"])):
         return None, "invalid"
 
     return to_unified(signal, chat_id, extra), None
 
 
-def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
+def parse_channel_four(
+    text: str, chat_id: int, *, return_meta: bool = False
+) -> Optional[Union[str, Tuple[str, Dict[str, Any]]]]:
     """Parser for Channel Four style messages supporting entry ranges."""
     if looks_like_update(text):
         log.info("IGNORED (update/noise)")
@@ -944,20 +954,25 @@ def parse_channel_four(text: str, chat_id: int) -> Optional[str]:
         "sl": sl,
         "tps": tps,
         "rr": rr,
+        "source": None,
+        "tf": None,
+        "entry_range": list(entry_range) if entry_range else None,
+        "notes": [],
         "extra": {},
     }
-    if entry_range:
-        signal["extra"]["entries"] = {"range": entry_range}
 
     if not is_valid(signal):
         log.info(f"IGNORED (invalid) -> {signal}")
         return None
     if not validate_directional_consistency(signal):
         return None
-    if not _validate_tp_sl(position, entry, sl, tps, entry_range):
+    if not _validate_tp_sl(position, entry, sl, tps, signal.get("entry_range")):
         return None
 
-    return to_unified(signal, chat_id, signal.get("extra", {}))
+    result = to_unified(signal, chat_id, signal.get("extra", {}))
+    if return_meta:
+        return result, signal
+    return result
 
 
 def parse_signal_classic(
@@ -986,7 +1001,7 @@ def parse_signal_classic(
     if _has_entry_range(text):
         if profile.get("allow_entry_range"):
             try:
-                return parse_channel_four(text, chat_id)
+                return parse_channel_four(text, chat_id, return_meta=return_meta)
             except Exception as e:
                 log.debug(f"Entry range parser failed: {e}")
                 return None
@@ -1013,6 +1028,11 @@ def parse_signal_classic(
         "sl": sl,
         "tps": tps,
         "rr": rr,
+        "source": None,
+        "tf": None,
+        "entry_range": None,
+        "notes": [],
+        "extra": {},
     }
 
     if not is_valid(signal):

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -88,8 +88,10 @@ def test_united_kings_entry_range_assignment(monkeypatch):
     message = """#XAUUSD\nBuy\n@1900-1910\nTP1 : 1915\nSL : 1890\n"""
     parse_signal_united_kings(message, 1234)
 
-    assert captured["signal"]["entry"] is None
-    assert captured["extra"]["entries"]["range"] == ["1900", "1910"]
+    assert captured["signal"]["entry_range"] == ["1900", "1910"]
+    assert captured["signal"]["source"] is None
+    assert captured["signal"]["tf"] is None
+    assert captured["signal"]["notes"] == []
     assert captured["extra"].get("show_entry_range_only") is True
 
 

--- a/tests/test_signal_fields.py
+++ b/tests/test_signal_fields.py
@@ -1,0 +1,23 @@
+import pytest
+from signal_bot import parse_signal
+
+def test_parse_signal_includes_required_fields():
+    message = "#XAUUSD\nBuy\nEntry Price : 1932\nTP1 : 1935\nSL : 1925\n"
+    result = parse_signal(message, 1234, return_meta=True)
+    assert result is not None
+    text, meta = result
+    assert meta["source"] is None
+    assert meta["tf"] is None
+    assert meta["entry_range"] is None
+    assert meta["notes"] == []
+
+def test_parse_signal_entry_range_fields():
+    profile = {"allow_entry_range": True}
+    message = "#XAUUSD\nBuy\nEntry: @1900-1910\nTP1: 1915\nTP2: 1920\nSL: 1890\n"
+    result = parse_signal(message, 1234, profile, return_meta=True)
+    assert result is not None
+    text, meta = result
+    assert meta["entry_range"] == ["1900", "1910"]
+    assert meta["source"] is None
+    assert meta["tf"] is None
+    assert meta["notes"] == []


### PR DESCRIPTION
## Summary
- Include `source`, `tf`, `entry_range`, and `notes` fields in parsed signals
- Validate stop-loss and take-profit positions against entry ranges
- Test that parsers populate these metadata fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48a806f6483239c29a66e53d6afea