### PR TITLE
Ensure meta is returned for United Kings signals

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -1130,18 +1130,27 @@ def parse_signal(
     is_united_kings = chat_id in UNITED_KINGS_CHAT_IDS or _looks_like_united_kings(text)
     if is_united_kings:
         try:
-            res, reason = parse_signal_united_kings(text, chat_id)
+            res, reason = parse_signal_united_kings(
+                text, chat_id, return_meta=return_meta
+            )
             if res is not None:
+                if return_meta:
+                    formatted = to_unified(res, chat_id, res.get("extra", {}))
+                    return formatted, res
                 return res
             if reason in {"no entry range", "no position"}:
-                return parse_signal_classic(text, chat_id, profile=profile, return_meta=return_meta)
+                return parse_signal_classic(
+                    text, chat_id, profile=profile, return_meta=return_meta
+                )
             else:
                 if reason:
                     log.info(f"IGNORED ({reason})")
                 return None
         except Exception as e:
             log.debug(f"United Kings parser failed: {e}")
-            return parse_signal_classic(text, chat_id, profile=profile, return_meta=return_meta)
+            return parse_signal_classic(
+                text, chat_id, profile=profile, return_meta=return_meta
+            )
 
     return parse_signal_classic(text, chat_id, profile=profile, return_meta=return_meta)
 

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -58,6 +58,20 @@ def test_parse_united_kings_valid(message, expected):
     assert parse_signal(message, 1234, {}) == expected
 
 
+def test_parse_united_kings_return_meta():
+    message, expected = VALID_SIGNALS[1]
+    result = parse_signal(message, 1234, return_meta=True)
+    assert result is not None
+    text, meta = result
+    assert text == expected
+    assert meta["symbol"] == "XAUUSD"
+    assert meta["position"] == "Buy"
+    assert meta["entry_range"] == ["1900", "1910"]
+    assert meta["tps"] == ["1915", "1920"]
+    assert meta["sl"] == "1890"
+    assert meta["rr"] == "1/1.5"
+
+
 @pytest.mark.parametrize("message", INVALID_SIGNALS)
 def test_parse_united_kings_invalid(message):
     assert parse_signal(message, 1234, {}) is None


### PR DESCRIPTION
## Summary
- Forward `return_meta` in `parse_signal` for United Kings style messages and build `(text, meta)` result
- Add test verifying `parse_signal(..., return_meta=True)` returns metadata for United Kings signals

## Testing
- `pytest tests/test_parse_united_kings.py::test_parse_united_kings_return_meta -q`
- `pytest tests/test_parse_united_kings.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4919cb5f48323ae4b67ccf4128aaf