### PR TITLE
Use regex search for United Kings entry range

### DIFF
--- a/parsers/united_kings.py
+++ b/parsers/united_kings.py
@@ -1,0 +1,26 @@
+import re
+from typing import Optional, Tuple
+
+ENTRY_RANGE_RE = re.compile(r"@?\s*(-?\d+(?:\.\d+)?)\s*[-\u2010-\u2015]\s*(-?\d+(?:\.\d+)?)")
+
+
+def parse_united_kings(t: str) -> Tuple[Optional[Tuple[float, float]], Optional[str]]:
+    """Extract the entry range from a United Kings style message.
+
+    Parameters
+    ----------
+    t: str
+        Message text possibly containing an entry range.
+
+    Returns
+    -------
+    Tuple[Optional[Tuple[float, float]], Optional[str]]
+        ``((lo, hi), None)`` if a range is found. Otherwise ``(None, "no entry range")``.
+    """
+    mrange = ENTRY_RANGE_RE.search(t)
+    if not mrange:
+        return None, "no entry range"
+    a = float(mrange.group(1))
+    b = float(mrange.group(2))
+    lo, hi = sorted((a, b))
+    return (lo, hi), None

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import signal_bot
 from signal_bot import parse_signal, parse_signal_united_kings
+from parsers.united_kings import parse_united_kings
 
 # Sample United Kings messages
 VALID_SIGNALS = [
@@ -183,4 +184,10 @@ def test_united_kings_direction_window_priority():
     )
     result, reason = parse_signal_united_kings(message, 1234)
     assert result and "Position: Buy" in result
+    assert reason is None
+
+
+def test_parse_united_kings_range_returns_bounds():
+    res, reason = parse_united_kings("Buy gold @1900-1910")
+    assert res == (1900.0, 1910.0)
     assert reason is None


### PR DESCRIPTION
## Summary
- Add dedicated `parsers.united_kings.parse_united_kings` using regex search instead of findall and sorting range bounds
- Exercise the range parser with a new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4942e48d883238ffb6da396f1964c