### PR TITLE
Route GOLD messages before United Kings VIP

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -1164,13 +1164,18 @@ def parse_message_by_source(
     routed to a channel-specific parser.
     """
     text = normalize_numbers(text)
+    gold_present = "GOLD" in (text or "").upper()
     lines = _strip_noise_lines((text or "").splitlines())
     text = "\n".join(lines)
     if not text:
         return None, "empty"
 
-    name = (source_name or "").lower()
-    if "united" in name and "kings" in name:
+    # Prioritise GOLD messages regardless of source naming
+    if gold_present:
+        return parse_gold_exclusive(text)
+
+    name = (source_name or "").strip().lower()
+    if name == "united kings vip":
         return parse_signal_united_kings(text, 0, return_meta=True)
     if "gold" in name and "exclusive" in name:
         return parse_gold_exclusive(text)

--- a/tests/test_parse_special_sources.py
+++ b/tests/test_parse_special_sources.py
@@ -3,6 +3,7 @@ from signal_bot import (
     parse_lingrid,
     parse_forex_rr,
     parse_message_by_source,
+    parse_signal_united_kings,
 )
 
 
@@ -93,4 +94,33 @@ def test_parse_message_by_source_routes():
     sig2, r2 = parse_gold_exclusive(msg)
     assert sig1 == sig2 and r1 is None and r2 is None
     sig3, r3 = parse_message_by_source(msg, "Unknown Channel")
-    assert sig3 is None and r3
+    assert sig3 == sig2 and r3 is None
+
+
+def test_parse_message_by_source_gold_keyword_priority():
+    msg = (
+        "Buy Gold now\n"
+        "Entry 1900\n"
+        "SL 1890\n"
+        "TP1: 1910\n"
+        "R/R 1:2\n"
+    )
+    sig1, r1 = parse_message_by_source(msg, "United Kings VIP")
+    sig2, r2 = parse_gold_exclusive(msg)
+    assert sig1 == sig2 and r1 is None and r2 is None
+
+
+def test_parse_message_by_source_united_kings_vip_only():
+    msg = (
+        "#XAUUSD\n"
+        "Buy\n"
+        "@1900-1910\n"
+        "TP1 : 1915\n"
+        "TP2 : 1920\n"
+        "SL : 1890\n"
+    )
+    sig1, r1 = parse_message_by_source(msg, "United Kings VIP")
+    sig2, r2 = parse_signal_united_kings(msg, 0, return_meta=True)
+    assert sig1 == sig2 and r1 is None and r2 is None
+    sig3, r3 = parse_message_by_source(msg, "United Kings Free")
+    assert sig3 is None and r3 == "unknown source"


### PR DESCRIPTION
## Summary
- Prioritize GOLD keyword in message routing and delegate to `parse_gold_exclusive`
- Restrict United Kings parsing to sources explicitly named "United Kings VIP"
- Add routing tests ensuring GOLD takes precedence and VIP-only United Kings parsing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4943f880483238c21d02dedc482b4