### PR TITLE
Handle 'Stop Loss (SL)' in United Kings parser

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -274,7 +274,13 @@ UNITED_KINGS_CHAT_IDS = {
 UK_RANGE_RE = re.compile(
     r"@?\s*(-?\d+(?:\.\d+)?)\s*[-\u2010-\u2015]\s*(-?\d+(?:\.\d+)?)"
 )
-UK_SL_RE = re.compile(r"\bS\s*L\s*[:@-]?\s*(-?\d+(?:\.\d+)?)", re.IGNORECASE)
+# SL lines may appear as plain "SL" or with optional "Stop Loss" text and
+# parentheses, e.g. "Stop Loss (SL)". The following regex captures the numeric
+# value while tolerating these variations.
+UK_SL_RE = re.compile(
+    r"\b(?:STOP\s*LOSS\s*)?\(?S\s*L\)?\s*[:@-]?\s*(-?\d+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
 UK_TP_RE = re.compile(r"\bT\s*P\s*\d*\s*[:@-]?\s*(-?\d+(?:\.\d+)?)", re.IGNORECASE)
 UK_NOISE_LINES = [
     re.compile(r"united\s+kings", re.IGNORECASE),

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -20,6 +20,11 @@ VALID_SIGNALS = [
         """\
 📊 #XAUUSD\n📉 Position: Sell\n❗️ R/R : 1/1\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1890\n✔️ TP2 : 1880\n🚫 Stop Loss : 1910""",
     ),
+    (
+        """#XAUUSD\nBuy gold\n@1900-1910\nTP1 : 1915\nTP2 : 1920\nStop Loss (SL) : 1890\n""",
+        """\
+📊 #XAUUSD\n📉 Position: Buy\n❗️ R/R : 1/1.5\n🎯 Entry Range : 1900 – 1910\n✔️ TP1 : 1915\n✔️ TP2 : 1920\n🚫 Stop Loss : 1890""",
+    ),
 ]
 
 INVALID_SIGNALS = [


### PR DESCRIPTION
## Summary
- allow SL lines prefixed with optional 'Stop Loss' and parentheses
- add regression test for 'Stop Loss (SL)' formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4994bbeb0832393483e536dc888a4