### PR TITLE
Allow non-digit separators in UK TP/SL parsing

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -274,14 +274,17 @@ UNITED_KINGS_CHAT_IDS = {
 UK_RANGE_RE = re.compile(
     r"@?\s*(-?\d+(?:\.\d+)?)\s*[-\u2010-\u2015]\s*(-?\d+(?:\.\d+)?)"
 )
-# SL lines may appear as plain "SL" or with optional "Stop Loss" text and
-# parentheses, e.g. "Stop Loss (SL)". The following regex captures the numeric
-# value while tolerating these variations.
+# SL and TP lines may include extra punctuation or descriptive text before the
+# numeric values. Allow any non-digit characters between the labels and numbers
+# so patterns like "Stop Loss (SL) :3454.5" are matched.
 UK_SL_RE = re.compile(
-    r"\b(?:STOP\s*LOSS\s*)?\(?S\s*L\)?\s*[:@-]?\s*(-?\d+(?:\.\d+)?)",
+    r"(?:stop\D*loss\D*\(?\D*sl\D*\)?|sl|set\D+your\D+sl\D+at)\D*(-?\d+(?:\.\d+)?)",
     re.IGNORECASE,
 )
-UK_TP_RE = re.compile(r"\bT\s*P\s*\d*\s*[:@-]?\s*(-?\d+(?:\.\d+)?)", re.IGNORECASE)
+UK_TP_RE = re.compile(
+    r"(?:tp\D*\d+|take\D*profit\D*\d+\D*\(?\D*tp\d+\D*\)?)\D*(-?\d+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
 UK_NOISE_LINES = [
     re.compile(r"united\s+kings", re.IGNORECASE),
     re.compile(r"tp\s+(?:hit|reached)", re.IGNORECASE),

--- a/tests/test_parse_united_kings.py
+++ b/tests/test_parse_united_kings.py
@@ -77,6 +77,13 @@ def test_parse_united_kings_return_meta():
     assert meta["rr"] == "1/1.5"
 
 
+def test_parse_united_kings_sl_with_parentheses_and_decimal():
+    message = (
+        "#XAUUSD\nBuy gold\n@3460-3470\nTP1 : 3480\nTP2 : 3490\nStop Loss (SL) :3454.5\n"
+    )
+    assert parse_signal(message, 1234, {}) is not None
+
+
 @pytest.mark.parametrize("message", INVALID_SIGNALS)
 def test_parse_united_kings_invalid(message):
     assert parse_signal(message, 1234, {}) is None


### PR DESCRIPTION
## Summary
- Relax United Kings SL/TP regex patterns to permit any non-digit separators so lines like `Stop Loss (SL) :3454.5` are recognized
- Add unit test for parsing SL lines with parenthesis, colon, and decimal values

## Testing
- `pytest tests/test_parse_united_kings.py tests/test_united_kings.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49ab3791083238d3b3446bbb5d964