### PR TITLE
Sanitize input with regex and expand invisible stripping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==3.0.3
 telethon==1.36.0
 gunicorn==22.0.0
 itsdangerous==2.2.0
+regex

--- a/tests/test_normalize_numbers.py
+++ b/tests/test_normalize_numbers.py
@@ -1,4 +1,4 @@
-from signal_bot import normalize_numbers
+from signal_bot import normalize_numbers, strip_invisibles
 
 
 def test_normalize_numbers_removes_commas():
@@ -18,3 +18,8 @@ def test_normalize_numbers_with_emojis_and_farsi_separators():
     text = "📈۱٬۲۳۴٬۵۶۷٫۸۹📉"
     assert normalize_numbers(text) == "📈1234567.89📉"
     assert normalize_numbers("💰۱۲۳۴۵۶💎") == "💰123456💎"
+
+
+def test_strip_invisibles_handles_emoji_and_bidi():
+    text = "\u2066💎#EURUSD💎\u2069"
+    assert strip_invisibles(normalize_numbers(text)) == "#EURUSD"

--- a/tests/test_pair_regex.py
+++ b/tests/test_pair_regex.py
@@ -1,6 +1,6 @@
 import pytest
 
-from signal_bot import guess_symbol
+from signal_bot import guess_symbol, strip_invisibles
 
 @pytest.mark.parametrize("text", ["UNITED", "ALRIGHT"])
 def test_invalid_words_not_matched(text):
@@ -30,8 +30,9 @@ def test_symbol_aliases(text, expected):
         ("🔥# EURUSD moon", "EURUSD"),
         ("#GBP\u00a0USD", "GBPUSD"),
         ("#EUR\u200fUSD", "EURUSD"),
+        ("\u2066🪙#USDJPY🪙\u2069", "USDJPY"),
     ],
 )
 def test_hashtags_with_emoji_or_invisible(text, expected):
-    assert guess_symbol(text) == expected
+    assert guess_symbol(strip_invisibles(text)) == expected
 


### PR DESCRIPTION
## Summary
- Replace `strip_invisibles` with regex-based implementation removing BIDI marks, non-breaking spaces and emoji
- Sanitize parser entry points with `strip_invisibles(normalize_numbers(text))`
- Simplify `guess_symbol` and handle spaced hashtags
- Add tests covering emoji/BIDI cleanup and spaced hashtags

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4a1c7df18832393c7dee00a76338e