### PR TITLE
Make UK Stop Loss regex handle optional SL

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -284,7 +284,7 @@ UK_RANGE_RE = re.compile(
 # numeric values. Allow any non-digit characters between the labels and numbers
 # so patterns like "Stop Loss (SL) :3454.5" are matched.
 UK_SL_RE = re.compile(
-    r"(?:stop\D*loss\D*\(?\D*sl\D*\)?|sl|set\D+your\D+sl\D+at)\D*(-?\d+(?:\.\d+)?)",
+    r"(?:stop\D*loss(?:\D*sl)?|sl|set\D+your\D+sl\D+at)\D*(-?\d+(?:\.\d+)?)",
     re.IGNORECASE,
 )
 UK_TP_RE = re.compile(


### PR DESCRIPTION
## Summary
- Make `SL` token optional after `Stop Loss` in United Kings parser so messages like "Stop Loss at 1890" parse correctly

## Testing
- `pytest tests/test_parse_united_kings.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4acd3afe88323bfb24c6bef229b79